### PR TITLE
fix: :zap: Add GitHub Keyword for linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@
 ---
 
 - [ ] Does your submission pass tests?
-- [ ] Have you lint your code locally prior to submission?
+- [ ] Have you lint your code locally prior to submission? Fixed:
+- [ ] This PR is for a new feature, not a bug fix.
 
 ### Changes to ⚙️ Core-Features:
 


### PR DESCRIPTION
Now submitted PRs can automatically linking to Issue if Issue Number is provided

Fixed: #341

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission?

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
