### PR TITLE
fix: :green_heart: Change workflow to github-script

### DIFF
--- a/.github/workflows/update-changelog.yaml
+++ b/.github/workflows/update-changelog.yaml
@@ -28,17 +28,28 @@ jobs:
           commit_message: Update CHANGELOG
           file_pattern: CHANGELOG.md
           create_branch: true
-      # Create Pull Request
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+      - name: Open Pull Request
+        uses: actions/github-script@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "docs: :memo: Update CHANGELOG for ${{ github.event.release.tag_name }}"
-          title: "docs: :memo: Update CHANGELOG for ${{ github.event.release.tag_name }}"
-          body: |
-            This Pull Request was automatically created by the Changelog Updater Action.
-            It updates the CHANGELOG.md with the release notes from the latest release.
-          branch: main
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const title = `Merge release/${{ github.event.release.tag_name }} into main`;
+            const body = `This PR merges release/${{ github.event.release.tag_name }} into main with auto-merge enabled. This PR updates the CHANGELOG.md file.`;
+            const head = `release/${{ github.event.release.tag_name }}`;
+            const base = 'main';
+            const auto_merge = true;
+            const draft = false;
+            const pr = await github.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              head,
+              base,
+              auto_merge,
+              draft
+            });
+            console.log(`Pull Request ${pr.data.number} created.`);
 
   Release-Documentation:
     if: ${{ contains(github.event.release.prerelease, false) }}


### PR DESCRIPTION
Change from `create-pull-request` to `github-script` to see if no **branch-policy** crash happens again

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
