### PR TITLE
fix: :bug: Update poetry-update log file name for commit message

### DIFF
--- a/.github/workflows/weekly-poetry-bot.yml
+++ b/.github/workflows/weekly-poetry-bot.yml
@@ -41,8 +41,8 @@ jobs:
           echo "No changes detected, creating an empty commit."
           git commit --allow-empty -m "chore(deps): :arrows_counterclockwise: no updates for $(date +%Y%m%d)"
         else
-          echo "Changes detected, creating a commit with update log."
-          update_log=$(cat update.log)
+          echo "Changes detected, creating a commit with poetry-update log."
+          update_log=$(cat poetry-update.log)
           git commit -m "$(echo -e "chore(deps): :arrows_counterclockwise: update dependencies $(date +%Y%m%d)\n\n$update_log")"
         fi
         git push origin update-dependencies-$(date +%Y%m%d)


### PR DESCRIPTION
Update script to use `poetry-update.log` instead of `update.log` for tracking dependencies.

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the log file name in the weekly poetry bot workflow to ensure the correct file is used for commit messages when tracking dependency updates.

Bug Fixes:
- Correct the log file name used in the commit message from `update.log` to `poetry-update.log` in the weekly poetry bot workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->