### PR TITLE
fix: Remove `git push`

### DIFF
--- a/.github/workflows/weekly-poetry-bot.yml
+++ b/.github/workflows/weekly-poetry-bot.yml
@@ -46,7 +46,6 @@ jobs:
           update_log=$(cat poetry-update.log)
           git commit -m "$(echo -e "chore(deps): :arrows_counterclockwise: update dependencies $(date +%Y%m%d)\n\n$update_log")"
         fi
-        git push origin update-dependencies-$(date +%Y%m%d)
 
     - name: Create Pull Request via gh
       run: >-


### PR DESCRIPTION
### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the `git push` command from the weekly-poetry-bot GitHub Actions workflow to prevent automatic pushing of updates.

CI:
- Remove the `git push` command from the weekly-poetry-bot GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->