### PR TITLE
fix: :heavy_minus_sign: Remove `git push`

### DIFF
--- a/.github/workflows/weekly-poetry-bot.yml
+++ b/.github/workflows/weekly-poetry-bot.yml
@@ -54,10 +54,6 @@ jobs:
           git commit -m "$(echo -e "chore(deps): :arrows_counterclockwise: update dependencies $(date +%Y%m%d%H%M)\n\n$update_log")"
         fi
 
-    - name: Push changes
-      run: |
-        git push -f origin update-dependencies-$(date +%Y%m%d%H%M)
-
     - name: Create Pull Request via gh
       run: |
         gh pr create --title "chore(deps): :arrows_counterclockwise: update dependencies $(date +%Y%m%d%H%M)" \


### PR DESCRIPTION
### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the 'git push' command from the 'weekly-poetry-bot' workflow to streamline the process and rely on GitHub CLI for creating pull requests.

CI:
- Remove the 'git push' step from the 'weekly-poetry-bot' GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->