### PR TITLE
chore: :recycle: update setup script to install UV via curl instead of pip

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,4 +1,4 @@
 python -m pip install --upgrade pip
-python -m pip install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv --python 3.10
 uv sync --all-extras --all-groups


### PR DESCRIPTION
### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

## Summary by Sourcery

Build:
- Install UV using curl.