### PR TITLE
chore: :recycle: Updated version from 1.3.0 to 1.4.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,17 +157,25 @@ exclude = ["docs/", "tools/", "spectrafit/test/", "spectrafit/**/test/"]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.ruff]
+fix = true
+include = ["*.py"]
+src = ["spectrafit"]
+target-version = "py38"
+
 [tool.ruff.lint]
 fixable = ["ALL"]
 extend-ignore = ["E721", "E731"]
 
+
 [tool.ruff.lint.isort]
-# known-first-party = ["spectrafit"]
 force-single-line = true
 lines-between-types = 1
-lines-after-imports = 2
+lines-after-imports = 4
 known-third-party = ["hatchling.build"]
 required-imports = ["from __future__ import annotations"]
+case-sensitive = true
+combine-as-imports = false
 
 [tool.pytest]
 script_launch_mode = "subprocess"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "SpectraFit"
-version = "1.3.0"
+version = "1.4.0"
 description = "Fast fitting of 2D- and 3D-Spectra with established routines"
 authors = [{ name = "Anselm Hahn", email = "anselm.hahn@gmail.com" }]
 requires-python = ">=3.8,<3.14"
@@ -160,6 +160,14 @@ build-backend = "hatchling.build"
 [tool.ruff.lint]
 fixable = ["ALL"]
 extend-ignore = ["E721", "E731"]
+
+[tool.ruff.lint.isort]
+# known-first-party = ["spectrafit"]
+force-single-line = true
+lines-between-types = 1
+lines-after-imports = 2
+known-third-party = ["hatchling.build"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.pytest]
 script_launch_mode = "subprocess"

--- a/spectrafit/__init__.py
+++ b/spectrafit/__init__.py
@@ -30,4 +30,4 @@ if sys.version_info[:2] == PYTHON_END_OF_LIFE:
         stacklevel=2,
     )
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"

--- a/spectrafit/__init__.py
+++ b/spectrafit/__init__.py
@@ -11,6 +11,8 @@
     [Release Schedule](https://devguide.python.org/versions/#end-of-life-branches).
 """
 
+from __future__ import annotations
+
 import sys
 import warnings
 from typing import Tuple

--- a/spectrafit/api/cmd_model.py
+++ b/spectrafit/api/cmd_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the command line interface."""
 
+from __future__ import annotations
+
 from datetime import datetime
 from getpass import getuser
 from hashlib import sha256

--- a/spectrafit/api/file_model.py
+++ b/spectrafit/api/file_model.py
@@ -1,5 +1,7 @@
 """Definition of the data file model."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Callable, List, Optional, Union
 

--- a/spectrafit/api/models_model.py
+++ b/spectrafit/api/models_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the models distributions."""
 
+from __future__ import annotations
+
 from typing import Callable, List, Optional
 
 from pydantic import BaseModel, Field

--- a/spectrafit/api/notebook_model.py
+++ b/spectrafit/api/notebook_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the Jupyter Notebook interface."""
 
+from __future__ import annotations
+
 from typing import List, Optional, Tuple, Union
 
 from _plotly_utils.colors.carto import Burg, Purp_r, Teal_r

--- a/spectrafit/api/pptx_model.py
+++ b/spectrafit/api/pptx_model.py
@@ -1,5 +1,7 @@
 """PPTXModel class for SpectraFit API."""
 
+from __future__ import annotations
+
 import re
 import tempfile
 from pathlib import Path

--- a/spectrafit/api/report_model.py
+++ b/spectrafit/api/report_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the Jupyter Notebook report."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Hashable, List, Union
 
 from dtale import __version__ as dtale_version

--- a/spectrafit/api/rixs_model.py
+++ b/spectrafit/api/rixs_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the Jupyter Notebook interface."""
 
+from __future__ import annotations
+
 from typing import Any, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/spectrafit/api/test/test_cmd_model.py
+++ b/spectrafit/api/test/test_cmd_model.py
@@ -1,5 +1,7 @@
 """Test of CMD and Tool Model."""
 
+from __future__ import annotations
+
 from getpass import getuser
 from hashlib import sha256
 from socket import gethostname

--- a/spectrafit/api/test/test_file_model.py
+++ b/spectrafit/api/test/test_file_model.py
@@ -1,5 +1,7 @@
 """Test the file model."""
 
+from __future__ import annotations
+
 import pytest
 
 from spectrafit.api.file_model import DataFileAPI

--- a/spectrafit/api/test/test_models_model.py
+++ b/spectrafit/api/test/test_models_model.py
@@ -1,5 +1,7 @@
 """Test the model model."""
 
+from __future__ import annotations
+
 import pytest
 
 from spectrafit.api.models_model import DistributionModelAPI

--- a/spectrafit/api/test/test_notebook_model.py
+++ b/spectrafit/api/test/test_notebook_model.py
@@ -1,5 +1,7 @@
 """Test of the notebook model."""
 
+from __future__ import annotations
+
 from math import isclose
 
 from _plotly_utils.colors.qualitative import Plotly as PlotlyColors

--- a/spectrafit/api/test/test_pptx_model.py
+++ b/spectrafit/api/test/test_pptx_model.py
@@ -1,5 +1,7 @@
 """Test the pptx_model module."""
 
+from __future__ import annotations
+
 from math import isclose
 from typing import Tuple, Type, Union
 

--- a/spectrafit/api/test/test_rixs_model.py
+++ b/spectrafit/api/test/test_rixs_model.py
@@ -1,5 +1,7 @@
 """Test of the RIXS Model API."""
 
+from __future__ import annotations
+
 import numpy as np
 
 from spectrafit.api.rixs_model import (

--- a/spectrafit/api/test/test_tools_model.py
+++ b/spectrafit/api/test/test_tools_model.py
@@ -1,5 +1,7 @@
 """Test of the Tools Model API."""
 
+from __future__ import annotations
+
 import pytest
 from pydantic import ValidationError
 

--- a/spectrafit/api/tools_model.py
+++ b/spectrafit/api/tools_model.py
@@ -1,5 +1,7 @@
 """Reference model for the API of the SpectraFit tools."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field

--- a/spectrafit/app/app.py
+++ b/spectrafit/app/app.py
@@ -1,5 +1,7 @@
 """Starting jupyter lab as a app."""
 
+from __future__ import annotations
+
 import sys
 
 from jupyterlab.labapp import main

--- a/spectrafit/app/test/test_app.py
+++ b/spectrafit/app/test/test_app.py
@@ -1,5 +1,7 @@
 """Test of the Jupiter plugin app."""
 
+from __future__ import annotations
+
 from unittest import mock
 
 

--- a/spectrafit/models.py
+++ b/spectrafit/models.py
@@ -1,5 +1,7 @@
 """Minimization models for curve fitting."""
 
+from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from math import log, pi, sqrt

--- a/spectrafit/plotting.py
+++ b/spectrafit/plotting.py
@@ -8,6 +8,8 @@
     the `plotting.py` file.
 """
 
+from __future__ import annotations
+
 from typing import Any, Dict, Optional
 
 import matplotlib.font_manager

--- a/spectrafit/plugins/color_schemas.py
+++ b/spectrafit/plugins/color_schemas.py
@@ -1,5 +1,7 @@
 """Color themes for the Plots in Jupyter Notebooks."""
 
+from __future__ import annotations
+
 from typing import List
 
 from spectrafit.api.notebook_model import ColorAPI, FontAPI

--- a/spectrafit/plugins/converter.py
+++ b/spectrafit/plugins/converter.py
@@ -1,5 +1,7 @@
 """Abstract base class for the converter plugins."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, MutableMapping

--- a/spectrafit/plugins/data_converter.py
+++ b/spectrafit/plugins/data_converter.py
@@ -1,5 +1,7 @@
 """Transform the input data to a CSV file."""
 
+from __future__ import annotations
+
 import argparse
 import re
 from dataclasses import dataclass

--- a/spectrafit/plugins/file_converter.py
+++ b/spectrafit/plugins/file_converter.py
@@ -1,5 +1,7 @@
 """Convert the input and output files to the preferred file format."""
 
+from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path

--- a/spectrafit/plugins/notebook.py
+++ b/spectrafit/plugins/notebook.py
@@ -1,5 +1,7 @@
 """Jupyter Notebook plugin for SpectraFit."""
 
+from __future__ import annotations
+
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/spectrafit/plugins/pkl_converter.py
+++ b/spectrafit/plugins/pkl_converter.py
@@ -1,5 +1,7 @@
 """Transform the raw pkl data into a CSV files."""
 
+from __future__ import annotations
+
 import argparse
 import gzip
 import pickle

--- a/spectrafit/plugins/pkl_visualizer.py
+++ b/spectrafit/plugins/pkl_visualizer.py
@@ -1,5 +1,7 @@
 """Visualize the pkl file as a graph."""
 
+from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path

--- a/spectrafit/plugins/pptx_converter.py
+++ b/spectrafit/plugins/pptx_converter.py
@@ -1,5 +1,7 @@
 """Convert the lock file to a powerpoint presentation."""
 
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
 from typing import Any, Dict, MutableMapping, Type

--- a/spectrafit/plugins/rixs_converter.py
+++ b/spectrafit/plugins/rixs_converter.py
@@ -1,5 +1,7 @@
 """Transform the raw pkl data into a JSON, TOML, or numpy file for RIXS."""
 
+from __future__ import annotations
+
 import argparse
 import json
 from pathlib import Path

--- a/spectrafit/plugins/rixs_visualizer.py
+++ b/spectrafit/plugins/rixs_visualizer.py
@@ -1,5 +1,7 @@
 """This module contains the RIXS visualizer class."""
 
+from __future__ import annotations
+
 import argparse
 import json
 import logging

--- a/spectrafit/plugins/test/test_color_schemas.py
+++ b/spectrafit/plugins/test/test_color_schemas.py
@@ -1,5 +1,7 @@
 """Test of the color schemas."""
 
+from __future__ import annotations
+
 from typing import Tuple, Type
 
 import pytest

--- a/spectrafit/plugins/test/test_converter.py
+++ b/spectrafit/plugins/test/test_converter.py
@@ -1,5 +1,7 @@
 """Test of the converter plugin."""
 
+from __future__ import annotations
+
 import gzip
 import json
 import pickle

--- a/spectrafit/plugins/test/test_notebook.py
+++ b/spectrafit/plugins/test/test_notebook.py
@@ -1,5 +1,7 @@
 """Test of the jupyter plugin."""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Union

--- a/spectrafit/plugins/test/test_rixs_visualizer.py
+++ b/spectrafit/plugins/test/test_rixs_visualizer.py
@@ -1,5 +1,7 @@
 """Test of the RIXS Visualizer."""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from typing import Any, Tuple

--- a/spectrafit/report.py
+++ b/spectrafit/report.py
@@ -1,5 +1,7 @@
 """Fit-Results as Report."""
 
+from __future__ import annotations
+
 import pprint
 import sys
 from typing import Any, Callable, Dict, Hashable, List, Optional, Tuple, Union

--- a/spectrafit/spectrafit.py
+++ b/spectrafit/spectrafit.py
@@ -1,5 +1,7 @@
 """SpectraFit, the command line tool for fitting."""
 
+from __future__ import annotations
+
 import argparse
 from typing import Any, Dict, MutableMapping, Optional, Tuple
 

--- a/spectrafit/test/test_init.py
+++ b/spectrafit/test/test_init.py
@@ -1,5 +1,7 @@
 """Tests for the SpectraFit __init__.py file."""
 
+from __future__ import annotations
+
 import importlib
 import sys
 import warnings

--- a/spectrafit/test/test_init.py
+++ b/spectrafit/test/test_init.py
@@ -12,7 +12,7 @@ from spectrafit import PYTHON_END_OF_LIFE, __version__
 
 def test_version() -> None:
     """Test the version string."""
-    assert __version__ == "1.3.0"
+    assert __version__ == "1.4.0"
 
 
 def test_python_end_of_life_warning(monkeypatch: MonkeyPatch) -> None:

--- a/spectrafit/test/test_input.py
+++ b/spectrafit/test/test_input.py
@@ -1,5 +1,7 @@
 """Testing of the command line interface."""
 
+from __future__ import annotations
+
 import sys
 from pathlib import Path
 from typing import Any

--- a/spectrafit/test/test_models.py
+++ b/spectrafit/test/test_models.py
@@ -1,5 +1,7 @@
 """Pytest of the model-module."""
 
+from __future__ import annotations
+
 import sys
 from math import isclose, log, pi, sqrt
 from typing import Any, Dict, Tuple

--- a/spectrafit/test/test_plot.py
+++ b/spectrafit/test/test_plot.py
@@ -1,5 +1,7 @@
 """Pytest of the plotting features of spectrafit."""
 
+from __future__ import annotations
+
 import pandas as pd
 from matplotlib import pyplot
 

--- a/spectrafit/test/test_report.py
+++ b/spectrafit/test/test_report.py
@@ -1,5 +1,7 @@
 """Pytest of report model."""
 
+from __future__ import annotations
+
 from math import isclose
 from typing import Any, Dict, List, Union
 

--- a/spectrafit/test/test_tools.py
+++ b/spectrafit/test/test_tools.py
@@ -1,5 +1,7 @@
 """Pytest of tools model."""
 
+from __future__ import annotations
+
 import gzip
 import pickle
 from pathlib import Path

--- a/spectrafit/tools.py
+++ b/spectrafit/tools.py
@@ -1,5 +1,7 @@
 """Collection of essential tools for running SpectraFit."""
 
+from __future__ import annotations
+
 import gzip
 import json
 import pickle

--- a/spectrafit/utilities/test/test_transformer.py
+++ b/spectrafit/utilities/test/test_transformer.py
@@ -1,5 +1,7 @@
 """Test of the jupyter plugin."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, List
 
 import pytest

--- a/spectrafit/utilities/transformer.py
+++ b/spectrafit/utilities/transformer.py
@@ -1,5 +1,7 @@
 """Transformer functions for the SpectraFit."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, List, Union
 
 from spectrafit.api.models_model import DistributionModelAPI

--- a/tools/spectra_generator.py
+++ b/tools/spectra_generator.py
@@ -1,7 +1,8 @@
 """Tools for generating spectra for testing."""
 
-import math
+from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import numpy as np

--- a/uv.lock
+++ b/uv.lock
@@ -7048,7 +7048,7 @@ wheels = [
 
 [[package]]
 name = "spectrafit"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "art" },


### PR DESCRIPTION
- Added `from __future__ import annotations` to enable postponed evaluation of type annotations.
- Organized import statements by grouping standard library imports, third-party imports, and local application imports.
- Removed redundant imports and ensured consistent formatting across various files in the `spectrafit` package.
- Updated version in `uv.lock` from 1.3.0 to 1.4.0.

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

## Summary by Sourcery

Update project version and improve type annotation and import organization

New Features:
- Added support for postponed type annotations using `from __future__ import annotations`

Enhancements:
- Organized import statements across the project
- Added Ruff configuration for import sorting

Chores:
- Bumped project version from 1.3.0 to 1.4.0