### PR TITLE
chore: :construction_worker: Update CI configuration to prevent Codecov from running if cancelled and modify pytest options for coverage reporting

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Test SpectraFit
         run: uv run --group dev --all-extras pytest spectrafit/
       - name: Codecov
-        if: ${{ !cancelled() }}
+        if: ${{ success() && !cancelled() }}
         uses: codecov/codecov-action@v5.4.3
         with:
           name: codecov-umbrella

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -57,6 +57,7 @@ jobs:
       - name: Test SpectraFit
         run: uv run --group dev --all-extras pytest spectrafit/
       - name: Codecov
+        if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5.4.3
         with:
           name: codecov-umbrella

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,7 @@ script_launch_mode = "subprocess"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "--cov=./spectrafit/ --cov-report=xml:coverage.xml --diff-symbols --plots -vv"
+addopts = "--cov --cov-report=xml:coverage.xml --junitxml=junit.xml -o junit_family=legacy --diff-symbols --plots -vv"
 testpaths = ["spectrafit"]
 markers = [
   "moessbauer: tests for Mössbauer spectroscopy models",


### PR DESCRIPTION
### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

## Summary by Sourcery

Improve CI reliability by skipping Codecov on cancelled runs and enhance test reporting by adjusting pytest coverage and JUnit output options

Enhancements:
- Simplify pytest coverage option and generate JUnit XML output with legacy family setting

CI:
- Add cancellation check to Codecov step to prevent uploads when workflow is cancelled