### PR TITLE
feat: :recycle: Refactor type hints to use built-in generic types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,9 @@ repos:
     hooks:
       - id: pydocstyle
         additional_dependencies: [toml>=0.10.2]
+  # pyupgrade for Python 3.9+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.2.0
+    hooks:
+      - id: pyupgrade
+        args: [--py39-plus, --keep-percent-format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ build-backend = "hatchling.build"
 fix = true
 include = ["*.py"]
 src = ["spectrafit"]
-target-version = "py38"
+target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/spectrafit/__init__.py
+++ b/spectrafit/__init__.py
@@ -16,12 +16,10 @@ from __future__ import annotations
 import sys
 import warnings
 
-from typing import Tuple
-
-from typing_extensions import Literal
+from typing import Literal
 
 
-PYTHON_END_OF_LIFE: Tuple[Literal[3], Literal[9]] = (3, 9)
+PYTHON_END_OF_LIFE: tuple[Literal[3], Literal[9]] = (3, 9)
 
 if sys.version_info[:2] == PYTHON_END_OF_LIFE:
     version_str = f"{PYTHON_END_OF_LIFE[0]}.{PYTHON_END_OF_LIFE[1]}"

--- a/spectrafit/api/cmd_model.py
+++ b/spectrafit/api/cmd_model.py
@@ -8,10 +8,6 @@ from getpass import getuser
 from hashlib import sha256
 from socket import gethostname
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -38,20 +34,20 @@ class DescriptionAPI(BaseModel):
         alias="projectDetails",
         description="Project details",
     )
-    keywords: List[str] = Field(
+    keywords: list[str] = Field(
         default=["spectra"],
         description="Keywords for the project",
     )
-    authors: List[str] = Field(
+    authors: list[str] = Field(
         default=["authors"],
         description="Authors of the project",
     )
-    references: List[str] = Field(
+    references: list[str] = Field(
         default=["https://github.com/Anselmoo/spectrafit"],
         alias="refs",
         description="References for the project",
     )
-    metadata: Optional[Union[Dict[Any, Any], List[Any]]] = Field(
+    metadata: dict[Any, Any] | list[Any] | None = Field(
         default=None,
         description="Metadata for the project",
     )
@@ -67,7 +63,7 @@ class DescriptionAPI(BaseModel):
 
     @field_validator("references")
     @classmethod
-    def check_references(cls, v: List[str]) -> Optional[List[str]]:
+    def check_references(cls, v: list[str]) -> list[str] | None:
         """Check if the list of references have valid URLs."""
         return [str(HttpUrl(url)) for url in v]
 
@@ -79,18 +75,18 @@ class CMDModelAPI(BaseModel):
     outfile: str = Field(default="spectrafit_results")
     input: str = Field(default="fitting_input.toml")
     oversampling: bool = DataPreProcessingAPI().oversampling
-    energy_start: Optional[float] = DataPreProcessingAPI().energy_start
-    energy_stop: Optional[float] = DataPreProcessingAPI().energy_stop
-    smooth: Optional[int] = DataPreProcessingAPI().smooth
-    shift: Optional[float] = DataPreProcessingAPI().shift
-    column: List[Union[int, str]] = DataPreProcessingAPI().column
+    energy_start: float | None = DataPreProcessingAPI().energy_start
+    energy_stop: float | None = DataPreProcessingAPI().energy_stop
+    smooth: int | None = DataPreProcessingAPI().smooth
+    shift: float | None = DataPreProcessingAPI().shift
+    column: list[int | str] = DataPreProcessingAPI().column
     separator: str = "\t"
     decimal: str = "."
-    header: Optional[int] = None
-    comment: Optional[str] = None
+    header: int | None = None
+    comment: str | None = None
     global_: int = Field(GlobalFittingAPI().global_)
-    autopeak: Union[AutopeakAPI, bool, Any] = False
+    autopeak: AutopeakAPI | bool | Any = False
     noplot: bool = False
     version: bool = False
     verbose: int = Field(default=0, ge=0, le=2)
-    description: Optional[DescriptionAPI] = Field(DescriptionAPI())
+    description: DescriptionAPI | None = Field(DescriptionAPI())

--- a/spectrafit/api/file_model.py
+++ b/spectrafit/api/file_model.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Callable
-from typing import List
-from typing import Optional
-from typing import Union
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -16,7 +13,7 @@ from pydantic.functional_validators import field_validator
 class DataFileAPI(BaseModel):
     """Definition of a data file."""
 
-    skiprows: Optional[int] = Field(
+    skiprows: int | None = Field(
         default=None,
         description="Number of lines to skip at the beginning of the file.",
     )
@@ -28,26 +25,26 @@ class DataFileAPI(BaseModel):
         ...,
         description="Delimiter to use.",
     )
-    comment: Optional[str] = Field(
+    comment: str | None = Field(
         default=None,
         description="Comment marker to use.",
     )
-    names: Optional[Callable[[Path, str], Optional[List[str]]]] = Field(
+    names: Callable[[Path, str], list[str] | None] | None = Field(
         default=None,
         description="Column names can be provided by list of strings or a function",
     )
-    header: Optional[Union[int, List[str]]] = Field(
+    header: int | list[str] | None = Field(
         default=None,
         description="Column headers to use.",
     )
-    file_suffixes: List[str] = Field(
+    file_suffixes: list[str] = Field(
         ...,
         description="File suffixes to use.",
     )
 
     @field_validator("delimiter")
     @classmethod
-    def check_delimiter(cls, v: str) -> Optional[str]:
+    def check_delimiter(cls, v: str) -> str | None:
         """Check if the delimiter is valid."""
         if v in {" ", "\t", ",", ";", "|", r"\s+"}:
             return v
@@ -56,7 +53,7 @@ class DataFileAPI(BaseModel):
 
     @field_validator("comment")
     @classmethod
-    def check_comment(cls, v: str) -> Optional[str]:
+    def check_comment(cls, v: str) -> str | None:
         """Check if the comment marker is valid."""
         if v is None or v in {"#", "%"}:
             return v

--- a/spectrafit/api/model_utils.py
+++ b/spectrafit/api/model_utils.py
@@ -6,9 +6,7 @@ ensuring type compatibility with mypy.
 
 from __future__ import annotations
 
-from typing import Dict
 from typing import Optional
-from typing import Union
 from typing import cast
 
 from spectrafit.api.moessbauer_model import AmplitudeAPI
@@ -20,7 +18,7 @@ from spectrafit.api.moessbauer_model import QuadrupoleSplittingAPI
 
 
 def create_amplitude_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> AmplitudeAPI:
     """Create an AmplitudeAPI instance from a dictionary.
 
@@ -51,7 +49,7 @@ def create_amplitude_api(
 
 
 def create_isomershift_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> IsomerShiftAPI:
     """Create an IsomerShiftAPI instance from a dictionary.
 
@@ -82,7 +80,7 @@ def create_isomershift_api(
 
 
 def create_fwhml_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> FwhmlAPI:
     """Create a FwhmlAPI instance from a dictionary.
 
@@ -113,7 +111,7 @@ def create_fwhml_api(
 
 
 def create_background_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> BackgroundAPI:
     """Create a BackgroundAPI instance from a dictionary.
 
@@ -144,7 +142,7 @@ def create_background_api(
 
 
 def create_quadrupolesplitting_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> QuadrupoleSplittingAPI:
     """Create a QuadrupoleSplittingAPI instance from a dictionary.
 
@@ -175,7 +173,7 @@ def create_quadrupolesplitting_api(
 
 
 def create_hyperfinefield_api(
-    data: Dict[str, Union[float, bool, None]],
+    data: dict[str, float | bool | None],
 ) -> HyperfineFieldAPI:
     """Create a HyperfineFieldAPI instance from a dictionary.
 

--- a/spectrafit/api/models_model.py
+++ b/spectrafit/api/models_model.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import Callable
-from typing import List
-from typing import Optional
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -21,31 +19,31 @@ __description__ = "Lmfit expression for explicit dependencies."
 class AmplitudeAPI(BaseModel):
     """Definition of the amplitude of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum amplitude.")
-    min: Optional[int] = Field(default=None, description="Minimum amplitude.")
+    max: float | None = Field(default=None, description="Maximum amplitude.")
+    min: int | None = Field(default=None, description="Minimum amplitude.")
     vary: bool = Field(default=True, description="Vary the amplitude.")
-    value: Optional[float] = Field(default=None, description="Initial Amplitude value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial Amplitude value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class CenterAPI(BaseModel):
     """Definition of the center of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum center.")
-    min: Optional[int] = Field(default=None, description="Minimum center.")
+    max: float | None = Field(default=None, description="Maximum center.")
+    min: int | None = Field(default=None, description="Minimum center.")
     vary: bool = Field(default=True, description="Vary the center.")
-    value: Optional[float] = Field(default=None, description="Initial Center value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial Center value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class FwhmgAPI(BaseModel):
     """Definition of the FWHM Gaussian of the models distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Full Width Half Maximum of the Gaussian Distribution.",
     )
-    min: Optional[int] = Field(
+    min: int | None = Field(
         default=None,
         description="Minimum Full Width Half Maximum of the Gaussian Distribution.",
     )
@@ -53,22 +51,22 @@ class FwhmgAPI(BaseModel):
         default=True,
         description="Vary the Full Width Half Maximum of the Gaussian Distribution.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Full Width Half Maximum of "
         "the Gaussian Distribution value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class FwhmlAPI(BaseModel):
     """Definition of the FWHM Lorentzian of the models distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Full Width Half Maximum of the Lorentzian Distribution.",
     )
-    min: Optional[int] = Field(
+    min: int | None = Field(
         default=None,
         description="Minimum Full Width Half Maximum of the Lorentzian Distribution.",
     )
@@ -76,22 +74,22 @@ class FwhmlAPI(BaseModel):
         default=True,
         description="Vary the Full Width Half Maximum of the Lorentzian Distribution.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Full Width Half Maximum of "
         "the Lorentzian Distribution value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class FwhmvAPI(BaseModel):
     """Definition of the FWHM Voigt of the models distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Full Width Half Maximum of the Voigt Distribution.",
     )
-    min: Optional[int] = Field(
+    min: int | None = Field(
         default=None,
         description="Minimum Full Width Half Maximum of the Voigt Distribution.",
     )
@@ -99,97 +97,97 @@ class FwhmvAPI(BaseModel):
         default=True,
         description="Vary the Full Width Half Maximum of the Voigt Distribution.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Full Width Half Maximum of the Voigt Distribution value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class WidthAPI(BaseModel):
     """Definition of the Width of the ORCA Gaussian of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum width.")
-    min: Optional[int] = Field(default=None, description="Minimum width.")
+    max: float | None = Field(default=None, description="Maximum width.")
+    min: int | None = Field(default=None, description="Minimum width.")
     vary: bool = Field(default=True, description="Vary the width.")
-    value: Optional[float] = Field(default=None, description="Initial width value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial width value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class GammaAPI(BaseModel):
     """Definition of the Gamma of the Voigt of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum gamma.")
-    min: Optional[int] = Field(default=None, description="Minimum gamma.")
+    max: float | None = Field(default=None, description="Maximum gamma.")
+    min: int | None = Field(default=None, description="Minimum gamma.")
     vary: bool = Field(default=True, description="Vary the gamma.")
-    value: Optional[float] = Field(default=None, description="Initial Gamma value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial Gamma value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class DecayAPI(BaseModel):
     """Definition of the Decay of the Exponential of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum decay rate.")
-    min: Optional[int] = Field(default=None, description="Minimum decay rate.")
+    max: float | None = Field(default=None, description="Maximum decay rate.")
+    min: int | None = Field(default=None, description="Minimum decay rate.")
     vary: bool = Field(default=True, description="Vary the decay rate.")
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial decay rate value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class InterceptAPI(BaseModel):
     """Definition of the Intercept of the Linear of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum intercept.")
-    min: Optional[int] = Field(default=None, description="Minimum intercept.")
+    max: float | None = Field(default=None, description="Maximum intercept.")
+    min: int | None = Field(default=None, description="Minimum intercept.")
     vary: bool = Field(default=True, description="Vary the intercept.")
-    value: Optional[float] = Field(default=None, description="Initial intercept value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial intercept value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class ExponentAPI(BaseModel):
     """Definition of the Exponent of the Linear of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum exponent.")
-    min: Optional[int] = Field(default=None, description="Minimum exponent.")
+    max: float | None = Field(default=None, description="Maximum exponent.")
+    min: int | None = Field(default=None, description="Minimum exponent.")
     vary: bool = Field(default=True, description="Vary the exponent.")
-    value: Optional[float] = Field(default=None, description="Initial exponent value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial exponent value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class SlopeAPI(BaseModel):
     """Definition of the Slope of the Linear of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum slope.")
-    min: Optional[int] = Field(default=None, description="Minimum slope.")
+    max: float | None = Field(default=None, description="Maximum slope.")
+    min: int | None = Field(default=None, description="Minimum slope.")
     vary: bool = Field(default=True, description="Vary the slope.")
-    value: Optional[float] = Field(default=None, description="Inital slope value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Inital slope value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class SigmaAPI(BaseModel):
     """Definition of the Sigma of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum sigma.")
-    min: Optional[int] = Field(default=None, description="Minimum sigma.")
+    max: float | None = Field(default=None, description="Maximum sigma.")
+    min: int | None = Field(default=None, description="Minimum sigma.")
     vary: bool = Field(default=True, description="Vary the sigma.")
-    value: Optional[float] = Field(default=None, description="Initial sigma value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial sigma value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class CoefficientAPI(BaseModel):
     """Definition of the Coefficient of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum coefficient.")
-    min: Optional[int] = Field(default=None, description="Minimum coefficient.")
+    max: float | None = Field(default=None, description="Maximum coefficient.")
+    min: int | None = Field(default=None, description="Minimum coefficient.")
     vary: bool = Field(default=True, description="Vary the coefficient.")
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial coefficient value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class PseudovoigtAPI(BaseModel):
@@ -338,21 +336,21 @@ class Polynomia3API(BaseModel):
 class SkewnessAPI(BaseModel):
     """Definition of the skewness of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum skewness.")
-    min: Optional[int] = Field(default=None, description="Minimum skewness.")
+    max: float | None = Field(default=None, description="Maximum skewness.")
+    min: int | None = Field(default=None, description="Minimum skewness.")
     vary: bool = Field(default=True, description="Vary the skewness.")
-    value: Optional[float] = Field(default=None, description="Initial skewness value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial skewness value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class KurtosisAPI(BaseModel):
     """Definition of the kurtosis of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum kurtosis.")
-    min: Optional[int] = Field(default=None, description="Minimum kurtosis.")
+    max: float | None = Field(default=None, description="Maximum kurtosis.")
+    min: int | None = Field(default=None, description="Minimum kurtosis.")
     vary: bool = Field(default=True, description="Vary the kurtosis.")
-    value: Optional[float] = Field(default=None, description="Initial kurtosis value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial kurtosis value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class Pearson1API(BaseModel):
@@ -429,7 +427,7 @@ class DistributionModelAPI(BaseModel):
 class ConfIntervalAPI(BaseModel):
     """Definition of Confidence Interval Function."""
 
-    p_names: Optional[List[str]] = Field(
+    p_names: list[str] | None = Field(
         default=None,
         description="List of parameters names.",
     )
@@ -447,7 +445,7 @@ class ConfIntervalAPI(BaseModel):
         default=False,
         description="Print information about the fit process.",
     )
-    prob_func: Optional[Callable[[float], float]] = Field(
+    prob_func: Callable[[float], float] | None = Field(
         default=None,
         description="Probing function.",
     )

--- a/spectrafit/api/moessbauer_model.py
+++ b/spectrafit/api/moessbauer_model.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Optional
-
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -15,21 +13,21 @@ __description__ = "Lmfit expression for explicit dependencies."
 class AmplitudeAPI(BaseModel):
     """Definition of the amplitude of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum amplitude.")
-    min: Optional[float] = Field(default=None, description="Minimum amplitude.")
+    max: float | None = Field(default=None, description="Maximum amplitude.")
+    min: float | None = Field(default=None, description="Minimum amplitude.")
     vary: bool = Field(default=True, description="Vary the amplitude.")
-    value: Optional[float] = Field(default=None, description="Initial Amplitude value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial Amplitude value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class CenterAPI(BaseModel):
     """Definition of the center of the models distributions."""
 
-    max: Optional[float] = Field(default=None, description="Maximum center.")
-    min: Optional[float] = Field(default=None, description="Minimum center.")
+    max: float | None = Field(default=None, description="Maximum center.")
+    min: float | None = Field(default=None, description="Minimum center.")
     vary: bool = Field(default=True, description="Vary the center.")
-    value: Optional[float] = Field(default=None, description="Initial Center value.")
-    expr: Optional[str] = Field(default=None, description=__description__)
+    value: float | None = Field(default=None, description="Initial Center value.")
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class IsomerShiftAPI(BaseModel):
@@ -39,11 +37,11 @@ class IsomerShiftAPI(BaseModel):
     Typically reported in mm/s.
     """
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum isomer shift value (mm/s).",
     )
-    min: Optional[float] = Field(
+    min: float | None = Field(
         default=None,
         description="Minimum isomer shift value (mm/s).",
     )
@@ -51,21 +49,21 @@ class IsomerShiftAPI(BaseModel):
         default=True,
         description="Vary the isomer shift parameter during fitting.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial isomer shift value (mm/s).",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class FwhmlAPI(BaseModel):
     """Definition of the FWHM Lorentzian of the models distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Full Width Half Maximum of the Lorentzian Distribution.",
     )
-    min: Optional[float] = Field(
+    min: float | None = Field(
         default=None,
         description="Minimum Full Width Half Maximum of the Lorentzian Distribution.",
     )
@@ -73,22 +71,22 @@ class FwhmlAPI(BaseModel):
         default=True,
         description="Vary the Full Width Half Maximum of the Lorentzian Distribution.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Full Width Half Maximum of "
         "the Lorentzian Distribution value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class QuadrupoleSplittingAPI(BaseModel):
     """Definition of the Quadrupole Splitting parameter for Mössbauer distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Quadrupole Splitting value.",
     )
-    min: Optional[float] = Field(
+    min: float | None = Field(
         default=None,
         description="Minimum Quadrupole Splitting value.",
     )
@@ -96,21 +94,21 @@ class QuadrupoleSplittingAPI(BaseModel):
         default=True,
         description="Vary the Quadrupole Splitting parameter during fitting.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Quadrupole Splitting value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class HyperfineFieldAPI(BaseModel):
     """Definition of the Hyperfine Field parameter for Mössbauer distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Hyperfine Field value.",
     )
-    min: Optional[float] = Field(
+    min: float | None = Field(
         default=None,
         description="Minimum Hyperfine Field value.",
     )
@@ -118,21 +116,21 @@ class HyperfineFieldAPI(BaseModel):
         default=True,
         description="Vary the Hyperfine Field parameter during fitting.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Hyperfine Field value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class BackgroundAPI(BaseModel):
     """Definition of the Background parameter for Mössbauer distributions."""
 
-    max: Optional[float] = Field(
+    max: float | None = Field(
         default=None,
         description="Maximum Background value.",
     )
-    min: Optional[float] = Field(
+    min: float | None = Field(
         default=None,
         description="Minimum Background value.",
     )
@@ -140,11 +138,11 @@ class BackgroundAPI(BaseModel):
         default=True,
         description="Vary the Background parameter during fitting.",
     )
-    value: Optional[float] = Field(
+    value: float | None = Field(
         default=None,
         description="Initial Background value.",
     )
-    expr: Optional[str] = Field(default=None, description=__description__)
+    expr: str | None = Field(default=None, description=__description__)
 
 
 class MoessbauerSingletAPI(BaseModel):
@@ -316,5 +314,5 @@ class DynamicParameter(BaseModel):
         default=False,
         description="Whether to vary this parameter in fitting",
     )
-    min: Optional[float] = Field(default=None, description="Minimum allowed value")
-    max: Optional[float] = Field(default=None, description="Maximum allowed value")
+    min: float | None = Field(default=None, description="Minimum allowed value")
+    max: float | None = Field(default=None, description="Maximum allowed value")

--- a/spectrafit/api/notebook_model.py
+++ b/spectrafit/api/notebook_model.py
@@ -2,11 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
-
 from _plotly_utils.colors.carto import Burg
 from _plotly_utils.colors.carto import Purp_r
 from _plotly_utils.colors.carto import Teal_r
@@ -20,7 +15,7 @@ class XAxisAPI(BaseModel):
     """Defintion of the X-Axis of the plotly figure."""
 
     name: str = Field(default="Energy", description="Name of the x-axis of the plot.")
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="eV",
         description="Name of the x-axis units of the plot.",
     )
@@ -33,7 +28,7 @@ class YAxisAPI(BaseModel):
         default="Intensity",
         description="Name of the y-axis of the plot.",
     )
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="a.u.",
         description="Name of the y-axis units of the plot.",
     )
@@ -51,7 +46,7 @@ class ResidualAPI(BaseModel):
         default="Residuals",
         description="Name of the residual-axis of the plot.",
     )
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="a.u.",
         description="Name of the residual-axis units of the plot.",
     )
@@ -64,7 +59,7 @@ class MetricAPI(BaseModel):
         default="Metrics",
         description="Name of the first metrics-axis of the plot.",
     )
-    unit_0: Optional[str] = Field(
+    unit_0: str | None = Field(
         default="a.u.",
         description="Name of the first metrics-axis units of the plot.",
     )
@@ -72,7 +67,7 @@ class MetricAPI(BaseModel):
         default="Metrics",
         description="Name of the second metrics-axis of the plot.",
     )
-    unit_1: Optional[str] = Field(
+    unit_1: str | None = Field(
         default="a.u.",
         description="Name of the second metrics-axis units of the plot.",
     )
@@ -82,7 +77,7 @@ class RunAPI(BaseModel):
     """Definition of the residual plot (Y-Axis) of the plotly figure."""
 
     name: str = Field(default="Run", description="Name of the Run-axis of the plot.")
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="#",
         description="Name of the run-axis units of the plot.",
     )
@@ -133,11 +128,11 @@ class ColorAPI(BaseModel):
         default=PlotlyColors[6],
         description="Color of the components, mainly peaks.",
     )
-    bars: List[str] = Field(
+    bars: list[str] = Field(
         default=[i for j in zip(Teal_r, Purp_r) for i in j],
         description="Color of the bar plot of the metrics.",
     )
-    lines: List[str] = Field(
+    lines: list[str] = Field(
         default=Burg,
         description="Color of the lines of the plot.",
     )
@@ -178,11 +173,11 @@ class PlotAPI(BaseModel):
     """Definition of the plotly figure."""
 
     x: str = Field(..., description="Name of the x column to plot.")
-    y: Union[str, List[str]] = Field(
+    y: str | list[str] = Field(
         ...,
         description="List of the names of the y columns to plot.",
     )
-    title: Optional[str] = Field(None, description="Title of the plot.")
+    title: str | None = Field(None, description="Title of the plot.")
     xaxis_title: XAxisAPI = XAxisAPI()
     yaxis_title: YAxisAPI = YAxisAPI()
     residual_title: ResidualAPI = ResidualAPI()
@@ -195,7 +190,7 @@ class PlotAPI(BaseModel):
     minor_ticks: bool = Field(default=True, description="Show minor ticks.")
     color: ColorAPI = ColorAPI()
     grid: GridAPI = GridAPI()
-    size: Tuple[int, Tuple[int, int]] = Field(
+    size: tuple[int, tuple[int, int]] = Field(
         default=(800, (600, 300)),
         description="Size of the fit- and metric-plot.",
     )
@@ -206,8 +201,8 @@ class FnameAPI(BaseModel):
 
     fname: str = Field(..., description="Name of the file to save.")
     suffix: str = Field(..., description="Suffix of the file to save.")
-    prefix: Optional[str] = Field(
+    prefix: str | None = Field(
         default=None,
         description="Prefix of the file to save.",
     )
-    folder: Optional[str] = Field(default=None, description="Folder to save the file.")
+    folder: str | None = Field(default=None, description="Folder to save the file.")

--- a/spectrafit/api/pptx_model.py
+++ b/spectrafit/api/pptx_model.py
@@ -7,11 +7,6 @@ import tempfile
 
 from pathlib import Path
 from typing import ClassVar
-from typing import Dict
-from typing import List
-from typing import Tuple
-from typing import Type
-from typing import Union
 
 import pandas as pd
 import pkg_resources
@@ -50,7 +45,7 @@ class InputAPI(BaseModel):
 class OutputAPI(BaseModel):
     """Dataframe class for PPTXData output."""
 
-    df_fit: Dict[str, List[float]]
+    df_fit: dict[str, list[float]]
 
 
 class GoodnessOfFitAPI(BaseModel):
@@ -65,13 +60,13 @@ class GoodnessOfFitAPI(BaseModel):
 class RegressionMetricsAPI(BaseModel):
     """RegressionMetrics class."""
 
-    index: List[str]
-    columns: List[int]
-    data: List[List[float]]
+    index: list[str]
+    columns: list[int]
+    data: list[list[float]]
 
     @field_validator("index")
     @classmethod
-    def short_metrics(cls, v: List[str]) -> List[str]:
+    def short_metrics(cls, v: list[str]) -> list[str]:
         """Shorten the metrics names.
 
         Args:
@@ -82,7 +77,7 @@ class RegressionMetricsAPI(BaseModel):
 
         """
         pattern = r"(?<!\d)[a-zA-Z0-9]{2,}(?!\d)"
-        abbreviations: Dict[str, str] = {}
+        abbreviations: dict[str, str] = {}
         min_abbrev_length = 2
         for metric in v:
             abbreviation = "".join(re.findall(pattern, metric)).lower()[
@@ -104,14 +99,14 @@ class SolverAPI(BaseModel):
 
     goodness_of_fit: GoodnessOfFitAPI
     regression_metrics: RegressionMetricsAPI
-    variables: Dict[str, Dict[str, float]]
+    variables: dict[str, dict[str, float]]
 
     @field_validator("variables")
     @classmethod
     def short_variables(
         cls,
-        v: Dict[str, Dict[str, float]],
-    ) -> Dict[str, Dict[str, float]]:
+        v: dict[str, dict[str, float]],
+    ) -> dict[str, dict[str, float]]:
         """Shorten the variables names.
 
         Args:
@@ -370,9 +365,9 @@ class PPTXLayoutAPI:
     """
 
     pptx_formats: ClassVar[
-        Dict[
+        dict[
             str,
-            Tuple[Type[Union[Field169API, Field169HDRAPI, Field43API]], Dict[str, int]],
+            tuple[type[Field169API | Field169HDRAPI | Field43API], dict[str, int]],
         ]
     ] = {
         "16:9": (Field169API, {"width": 1280, "height": 720}),
@@ -641,7 +636,7 @@ class PPTXLayoutAPI:
             fname=PPTXBasicTitleAPI().credit_logo,
         )
 
-    def get_pptx_layout(self) -> Union[Field169API, Field169HDRAPI, Field43API]:
+    def get_pptx_layout(self) -> Field169API | Field169HDRAPI | Field43API:
         """Get the powerpoint presentation layout.
 
         Returns:

--- a/spectrafit/api/report_model.py
+++ b/spectrafit/api/report_model.py
@@ -2,11 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Hashable
 from typing import Any
-from typing import Dict
-from typing import Hashable
-from typing import List
-from typing import Union
 
 from dtale import __version__ as dtale_version
 from emcee import __version__ as emcee_version
@@ -48,19 +45,19 @@ class CreditsAPI(BaseModel):
 class FitMethodAPI(BaseModel):
     """Fit method API model."""
 
-    global_fitting: Union[bool, int] = Field(
+    global_fitting: bool | int = Field(
         default=False,
         description="Fitting in the global fashion",
     )
-    confidence_interval: Union[bool, Dict[str, Any]] = Field(
+    confidence_interval: bool | dict[str, Any] = Field(
         ...,
         description="Settings for the confidence interval calculation",
     )
-    configurations: Dict[str, Any] = Field(
+    configurations: dict[str, Any] = Field(
         ...,
         description="Settings for the fitting configuration",
     )
-    settings_solver_models: Dict[str, Any] = Field(
+    settings_solver_models: dict[str, Any] = Field(
         ...,
         description="Settings for the solver models including minimizer and optimizer",
     )
@@ -71,7 +68,7 @@ class InputAPI(BaseModel):
 
     description: DescriptionAPI = DescriptionAPI()
     credits: CreditsAPI = CreditsAPI()
-    initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]] = Field(
+    initial_model: list[dict[str, dict[str, dict[str, Any]]]] = Field(
         ...,
         description="Initial model for the fit",
     )
@@ -85,40 +82,40 @@ class InputAPI(BaseModel):
 class SolverAPI(BaseModel):
     """Solver API for the report endpoint."""
 
-    goodness_of_fit: Dict[str, float] = Field(..., description="Goodness of fit")
-    regression_metrics: Dict[str, List[Any]] = Field(
+    goodness_of_fit: dict[str, float] = Field(..., description="Goodness of fit")
+    regression_metrics: dict[str, list[Any]] = Field(
         ...,
         description="Regression metrics",
     )
-    descriptive_statistic: Dict[str, List[Any]] = Field(
+    descriptive_statistic: dict[str, list[Any]] = Field(
         ...,
         description="Descriptive statistic",
     )
-    linear_correlation: Dict[str, List[Any]] = Field(
+    linear_correlation: dict[str, list[Any]] = Field(
         ...,
         description="Linear correlation",
     )
-    component_correlation: Dict[str, Dict[str, Any]] = Field(
+    component_correlation: dict[str, dict[str, Any]] = Field(
         default={},
         description="Linear correlation of each attribute of components. if possible",
     )
-    confidence_interval: Dict[str, Any] = Field(
+    confidence_interval: dict[str, Any] = Field(
         default={},
         description="Confidence interval, if possible",
     )
-    covariance_matrix: Dict[str, Dict[str, Any]] = Field(
+    covariance_matrix: dict[str, dict[str, Any]] = Field(
         default={},
         description="Covariance matrix, if possible",
     )
-    variables: Dict[str, Dict[str, Any]] = Field(
+    variables: dict[str, dict[str, Any]] = Field(
         ...,
         description="Variables with their initial, optimized and optional error values",
     )
-    errorbars: Dict[str, Any] = Field(
+    errorbars: dict[str, Any] = Field(
         default={},
         description="Error bar comment if values reach initial value or boundary",
     )
-    computational: Dict[str, Any] = Field(
+    computational: dict[str, Any] = Field(
         ...,
         description="Computational information like number of function evaluations",
     )
@@ -127,15 +124,15 @@ class SolverAPI(BaseModel):
 class OutputAPI(BaseModel):
     """Output API for the report endpoint."""
 
-    df_org: Dict[Hashable, Any] = Field(
+    df_org: dict[Hashable, Any] = Field(
         ...,
         description="DataFrame of the original data via 'records' orient",
     )
-    df_fit: Dict[Hashable, Any] = Field(
+    df_fit: dict[Hashable, Any] = Field(
         ...,
         description="DataFrame of the fitted data via 'records' orient",
     )
-    df_pre: Dict[Hashable, Any] = Field(
+    df_pre: dict[Hashable, Any] = Field(
         default={},
         description="DataFrame of the pre-processed data via 'records' orient",
     )

--- a/spectrafit/api/rixs_model.py
+++ b/spectrafit/api/rixs_model.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Optional
-from typing import Tuple
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -18,7 +16,7 @@ class XAxisAPI(BaseModel):
         default="Incident Energy",
         description="Name of the x-axis of the plot.",
     )
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="eV",
         description="Name of the x-axis units of the plot.",
     )
@@ -31,7 +29,7 @@ class YAxisAPI(BaseModel):
         default="Emission Energy",
         description="Name of the y-axis of the plot.",
     )
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="eV",
         description="Name of the y-axis units of the plot.",
     )
@@ -44,7 +42,7 @@ class ZAxisAPI(BaseModel):
         default="Intensity",
         description="Name of the z-axis of the plot.",
     )
-    unit: Optional[str] = Field(
+    unit: str | None = Field(
         default="a.u.",
         description="Name of the z-axis units of the plot.",
     )
@@ -61,19 +59,19 @@ class MainTitleAPI(BaseModel):
 class SizeRatioAPI(BaseModel):
     """Defintion of the size ratio of the plotly figure."""
 
-    size: Tuple[int, int] = Field(
+    size: tuple[int, int] = Field(
         default=(500, 500),
         description="Basic size of the plots in pixels.",
     )
-    ratio_rixs: Tuple[float, float] = Field(
+    ratio_rixs: tuple[float, float] = Field(
         default=(2, 2),
         description="Ratio of the RIXS plot.",
     )
-    ratio_xes: Tuple[float, float] = Field(
+    ratio_xes: tuple[float, float] = Field(
         default=(3, 1),
         description="Ratio of the XES plot.",
     )
-    ratio_xas: Tuple[float, float] = Field(
+    ratio_xas: tuple[float, float] = Field(
         default=(3, 1),
         description="Ratio of the XAS plot.",
     )
@@ -112,11 +110,11 @@ class RIXSPlotAPI(BaseModel):
         ...,
         description="Emission intensity values (RIXS), which has to be a 2D array.",
     )  # Should be NDArray[np.float64] but that's not supported for 3.8
-    energy_loss: Optional[Any] = Field(
+    energy_loss: Any | None = Field(
         default=None,
         description="Energy loss values.",
     )  # Should be NDArray[np.float64] but that's not supported for 3.8
-    energy_loss_intensity: Optional[Any] = Field(
+    energy_loss_intensity: Any | None = Field(
         default=None,
         description="Energy loss intensity values (XES), which has to be a 2D array.",
     )  # Should be NDArray[np.float64] but that's not supported for 3.8

--- a/spectrafit/api/test/test_pptx_model.py
+++ b/spectrafit/api/test/test_pptx_model.py
@@ -3,9 +3,6 @@
 from __future__ import annotations
 
 from math import isclose
-from typing import Tuple
-from typing import Type
-from typing import Union
 
 import pandas as pd
 import pytest
@@ -108,7 +105,7 @@ def test_solver() -> None:
 
 
 @pytest.fixture
-def pptx_data(project_name: str) -> Tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI]:
+def pptx_data(project_name: str) -> tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI]:
     """Return a PPTXData object."""
     method = MethodAPI(global_fitting=True)
     description = DescriptionAPI(project_name=project_name, version="1.0")
@@ -145,7 +142,7 @@ def pptx_data(project_name: str) -> Tuple[PPTXDataAPI, OutputAPI, InputAPI, Solv
 
 
 def test_pptx_data(
-    pptx_data: Tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
+    pptx_data: tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
 ) -> None:
     """Test the PPTXData class."""
     assert pptx_data[0].output == pptx_data[1]
@@ -156,7 +153,7 @@ def test_pptx_data(
 @pytest.mark.parametrize("format_str", ["16:9", "16:9HDR", "4:3"])
 def test_pptx_layout_init(
     format_str: str,
-    pptx_data: Tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
+    pptx_data: tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
     project_name: str,
 ) -> None:
     """Test the PPTXLayout class."""
@@ -170,7 +167,7 @@ def test_pptx_layout_init(
 
 def test_pptx_layout_tmp_plot(
     project_name: str,
-    pptx_data: Tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
+    pptx_data: tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
 ) -> None:
     """Test the PPTXLayout class."""
     layout = PPTXLayoutAPI(project_name, pptx_data[0])
@@ -185,8 +182,8 @@ def test_pptx_layout_tmp_plot(
 )
 def test_get_pptx_layout(
     format_str: str,
-    pptx_data: Tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
-    expected_output: Type[Union[Field169API, Field169HDRAPI, Field43API]],
+    pptx_data: tuple[PPTXDataAPI, OutputAPI, InputAPI, SolverAPI],
+    expected_output: type[Field169API | Field169HDRAPI | Field43API],
 ) -> None:
     """Test the PPTXLayout class."""
     layout = PPTXLayoutAPI(format_str, pptx_data[0])

--- a/spectrafit/api/test/test_utils_model.py
+++ b/spectrafit/api/test/test_utils_model.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import Type
-from typing import Union
 
 import numpy as np
 import pytest
@@ -27,7 +24,7 @@ from spectrafit.api.moessbauer_model import QuadrupoleSplittingAPI
 
 def test_create_quadrupolesplitting_api_basic() -> None:
     """Test creating QuadrupoleSplittingAPI with basic parameters."""
-    data: Dict[str, Union[float, bool, None]] = {
+    data: dict[str, float | bool | None] = {
         "value": 0.5,
         "min": -1.0,
         "max": 1.0,
@@ -48,7 +45,7 @@ def test_create_quadrupolesplitting_api_basic() -> None:
 
 def test_create_quadrupolesplitting_api_all_params() -> None:
     """Test creating QuadrupoleSplittingAPI with all parameters."""
-    data: Dict[str, Union[float, bool, None, str]] = {
+    data: dict[str, float | bool | None | str] = {
         "value": 0.3,
         "min": -0.5,
         "max": 0.5,
@@ -71,7 +68,7 @@ def test_create_quadrupolesplitting_api_all_params() -> None:
 
 def test_create_quadrupolesplitting_api_none_values() -> None:
     """Test creating QuadrupoleSplittingAPI with None values."""
-    data: Dict[str, Union[float, bool, None]] = {
+    data: dict[str, float | bool | None] = {
         "value": None,
         "min": None,
         "max": None,
@@ -90,7 +87,7 @@ def test_create_quadrupolesplitting_api_none_values() -> None:
 
 def test_create_quadrupolesplitting_api_empty_dict() -> None:
     """Test creating QuadrupoleSplittingAPI with empty dictionary."""
-    data: Dict[str, Union[float, bool, None]] = {}
+    data: dict[str, float | bool | None] = {}
 
     result = create_quadrupolesplitting_api(data)
 
@@ -104,7 +101,7 @@ def test_create_quadrupolesplitting_api_empty_dict() -> None:
 
 def test_create_hyperfinefield_api_basic() -> None:
     """Test creating HyperfineFieldAPI with basic parameters."""
-    data: Dict[str, Union[float, bool, None]] = {
+    data: dict[str, float | bool | None] = {
         "value": 30.0,
         "min": 0.0,
         "max": 50.0,
@@ -125,7 +122,7 @@ def test_create_hyperfinefield_api_basic() -> None:
 
 def test_create_hyperfinefield_api_all_params() -> None:
     """Test creating HyperfineFieldAPI with all parameters."""
-    data: Dict[str, Union[float, bool, None, str]] = {
+    data: dict[str, float | bool | None | str] = {
         "value": 25.0,
         "min": 10.0,
         "max": 40.0,
@@ -158,8 +155,8 @@ def test_create_hyperfinefield_api_all_params() -> None:
     ],
 )
 def test_factory_functions_consistency(
-    factory_func: Callable[[Dict[str, Union[float, bool, None]]], Any],
-    api_class: Type[Any],
+    factory_func: Callable[[dict[str, float | bool | None]], Any],
+    api_class: type[Any],
     test_value: float,
 ) -> None:
     """Test consistency of factory function behavior across different API models.
@@ -169,7 +166,7 @@ def test_factory_functions_consistency(
         api_class: Expected API class type
         test_value: Test value for parameter
     """
-    data: Dict[str, Union[float, bool, None, str]] = {
+    data: dict[str, float | bool | None | str] = {
         "value": test_value,
         "min": test_value / 2,
         "max": test_value * 2,
@@ -199,8 +196,8 @@ def test_factory_functions_consistency(
     ],
 )
 def test_factory_functions_with_boolean_strings(
-    factory_func: Callable[[Dict[str, Union[float, bool, None]]], Any],
-    api_class: Type[Any],
+    factory_func: Callable[[dict[str, float | bool | None]], Any],
+    api_class: type[Any],
 ) -> None:
     """Test handling of boolean values that might come from serialized data.
 
@@ -209,11 +206,11 @@ def test_factory_functions_with_boolean_strings(
         api_class: Expected API class type
     """
     # Test with boolean values
-    data_true: Dict[str, Union[float, bool, None]] = {"value": 1.0, "vary": True}
+    data_true: dict[str, float | bool | None] = {"value": 1.0, "vary": True}
     result_true = factory_func(data_true)
     assert result_true.vary is True
 
-    data_false: Dict[str, Union[float, bool, None]] = {"value": 1.0, "vary": False}
+    data_false: dict[str, float | bool | None] = {"value": 1.0, "vary": False}
     result_false = factory_func(data_false)
     assert result_false.vary is False
 
@@ -221,7 +218,7 @@ def test_factory_functions_with_boolean_strings(
 def test_create_api_with_mixed_types() -> None:
     """Test creating API models with mixed data types for vary parameter."""
     # Test with integer 0 (should convert to False)
-    data: Dict[str, Union[float, bool, None]] = {
+    data: dict[str, float | bool | None] = {
         "value": 0.5,
         "vary": 0,
     }

--- a/spectrafit/api/tools_model.py
+++ b/spectrafit/api/tools_model.py
@@ -3,10 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -24,15 +20,15 @@ class AutopeakAPI(BaseModel):
     )
     """
 
-    modeltype: Optional[str] = None
-    height: Optional[List[float]] = None
-    threshold: Optional[List[float]] = None
-    distance: Optional[int] = None
-    prominence: Optional[List[float]] = None
-    width: Optional[List[float]] = None
-    wlen: Optional[int] = None
-    rel_height: Optional[float] = None
-    plateau_size: Optional[float] = None
+    modeltype: str | None = None
+    height: list[float] | None = None
+    threshold: list[float] | None = None
+    distance: int | None = None
+    prominence: list[float] | None = None
+    width: list[float] | None = None
+    wlen: int | None = None
+    rel_height: float | None = None
+    plateau_size: float | None = None
     model_config = ConfigDict(extra="forbid", validate_assignment=True)
 
 
@@ -43,11 +39,11 @@ class DataPreProcessingAPI(BaseModel):
         default=False,
         description="Oversampling the spectra by using factor of 5; default to False.",
     )
-    energy_start: Optional[float] = Field(
+    energy_start: float | None = Field(
         default=None,
         description="Start energy of the spectra; default to None.",
     )
-    energy_stop: Optional[float] = Field(
+    energy_stop: float | None = Field(
         default=None,
         description="Stop energy of the spectra; default to None.",
     )
@@ -60,7 +56,7 @@ class DataPreProcessingAPI(BaseModel):
         default=0,
         description="Shift the energy axis; default to 0.",
     )
-    column: List[Union[int, str]] = Field(
+    column: list[int | str] = Field(
         min_length=1,
         default=[0, 1],
         description="Column of the data.",
@@ -76,11 +72,11 @@ class GlobalFittingAPI(BaseModel):
 class SolverModelsAPI(BaseModel):
     """Definition of the solver of SpectraFit."""
 
-    minimizer: Dict[str, Any] = Field(
+    minimizer: dict[str, Any] = Field(
         default={"nan_policy": "propagate", "calc_covar": True},
         description="Minimizer options",
     )
-    optimizer: Dict[str, Any] = Field(
+    optimizer: dict[str, Any] = Field(
         default={"max_nfev": None, "method": "leastsq"},
         description="Optimzer options",
     )
@@ -96,8 +92,8 @@ class GeneralSolverModelsAPI(BaseModel):
     """
 
     global_: int = GlobalFittingAPI().global_
-    minimizer: Dict[str, Any] = SolverModelsAPI().minimizer
-    optimizer: Dict[str, Any] = SolverModelsAPI().optimizer
+    minimizer: dict[str, Any] = SolverModelsAPI().minimizer
+    optimizer: dict[str, Any] = SolverModelsAPI().optimizer
 
 
 class ColumnNamesAPI(BaseModel):

--- a/spectrafit/models/builtin.py
+++ b/spectrafit/models/builtin.py
@@ -10,10 +10,6 @@ from math import sqrt
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import Optional
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 
@@ -165,7 +161,7 @@ class DistributionModels:
         x: NDArray[np.float64],
         center: float = 0.0,
         fwhmv: float = 1.0,
-        gamma: Optional[float] = None,
+        gamma: float | None = None,
     ) -> NDArray[np.float64]:
         r"""Return a 1-dimensional Voigt distribution.
 
@@ -833,7 +829,7 @@ class DistributionModels:
         quadrupoleshift: float = 0.0,
         center: float = 0.0,
         background: float = 0.0,
-        anglethetaphi: Optional[Dict[str, float]] = None,
+        anglethetaphi: dict[str, float] | None = None,
     ) -> NDArray[np.float64]:
         """Compute a Mössbauer sextet via six Lorentzians plus background.
 
@@ -875,7 +871,7 @@ class DistributionModels:
         center: float = 0.0,
         efg_vzz: float = 1e21,
         efg_eta: float = 0.0,
-        anglethetaphi: Optional[Dict[str, float]] = None,
+        anglethetaphi: dict[str, float] | None = None,
         temperature: float = 300.0,
         sodshift: float = 0.0,
         sitefraction: float = 1.0,
@@ -983,7 +979,7 @@ class ReferenceKeys:
             msg = f"{model} is not supported for auto detection! Use one of {self.__automodels__}"
             raise KeyError(msg)
 
-    def detection_check(self, args: Dict[str, Any]) -> None:
+    def detection_check(self, args: dict[str, Any]) -> None:
         """Check if detection is available.
 
         Args:
@@ -1005,7 +1001,7 @@ class AutoPeakDetection:
         self,
         x: NDArray[np.float64],
         data: NDArray[np.float64],
-        args: Dict[str, Any],
+        args: dict[str, Any],
     ) -> None:
         """Initialize the AutoPeakDetection class.
 
@@ -1023,8 +1019,8 @@ class AutoPeakDetection:
     @staticmethod
     def check_key_exists(
         key: str,
-        args: Dict[str, Any],
-        value: Union[float, Tuple[Any, Any]],
+        args: dict[str, Any],
+        value: float | tuple[Any, Any],
     ) -> Any:
         """Check if a key exists in a dictionary.
 
@@ -1048,7 +1044,7 @@ class AutoPeakDetection:
         return args.get(key, value)
 
     @property
-    def estimate_height(self) -> Tuple[float, float]:
+    def estimate_height(self) -> tuple[float, float]:
         r"""Estimate the initial height based on an inverse noise ratio of a signal.
 
         !!! info "About the estimation of the height"
@@ -1073,7 +1069,7 @@ class AutoPeakDetection:
         return 1 - self.data.mean() / self.data.std(), self.data.max()
 
     @property
-    def estimate_threshold(self) -> Tuple[float, float]:
+    def estimate_threshold(self) -> tuple[float, float]:
         """Estimate the threshold value for the peak detection.
 
         Returns:
@@ -1095,7 +1091,7 @@ class AutoPeakDetection:
         return max(min_step, 1.0)
 
     @property
-    def estimate_prominence(self) -> Tuple[float, float]:
+    def estimate_prominence(self) -> tuple[float, float]:
         """Estimate the prominence of a peak.
 
         !!! info "About the estimation of the prominence"
@@ -1116,7 +1112,7 @@ class AutoPeakDetection:
         return self.data.mean(), self.data.max()
 
     @property
-    def estimated_width(self) -> Tuple[float, float]:
+    def estimated_width(self) -> tuple[float, float]:
         """Estimate the width of a peak.
 
         !!! info "About the estimation of the width"
@@ -1175,7 +1171,7 @@ class AutoPeakDetection:
         return wlen if wlen > 1.0 else 1 + 1e-9
 
     @property
-    def estimated_plateau_size(self) -> Tuple[float, float]:
+    def estimated_plateau_size(self) -> tuple[float, float]:
         """Estimate the plateau size for the peak detection.
 
         Returns:
@@ -1276,7 +1272,7 @@ class AutoPeakDetection:
 class ModelParameters(AutoPeakDetection):
     """Class to define the model parameters."""
 
-    def __init__(self, df: pd.DataFrame, args: Dict[str, Any]) -> None:
+    def __init__(self, df: pd.DataFrame, args: dict[str, Any]) -> None:
         """Initialize the model parameters.
 
         Args:
@@ -1318,8 +1314,8 @@ class ModelParameters(AutoPeakDetection):
     def df_to_numvalues(
         self,
         df: pd.DataFrame,
-        args: Dict[str, Any],
-    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+        args: dict[str, Any],
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Transform the dataframe to numeric values of `x` and `data`.
 
         !!! note "About the dataframe to numeric values"
@@ -1579,7 +1575,7 @@ class ModelParameters(AutoPeakDetection):
         for key_1, value_1 in self.args["peaks"].items():
             self.define_parameters_loop(key_1=key_1, value_1=value_1)
 
-    def define_parameters_loop(self, key_1: str, value_1: Dict[str, Any]) -> None:
+    def define_parameters_loop(self, key_1: str, value_1: dict[str, Any]) -> None:
         """Loop through the input parameters for a `params`-dictionary.
 
         Args:
@@ -1595,7 +1591,7 @@ class ModelParameters(AutoPeakDetection):
         self,
         key_1: str,
         key_2: str,
-        value_2: Dict[str, Any],
+        value_2: dict[str, Any],
     ) -> None:
         """Loop through the input parameters for a `params`-dictionary.
 
@@ -1619,7 +1615,7 @@ class ModelParameters(AutoPeakDetection):
         key_1: str,
         key_2: str,
         key_3: str,
-        value_3: Dict[str, Any],
+        value_3: dict[str, Any],
     ) -> None:
         """Loop through the input parameters for a `params`-dictionary.
 
@@ -1653,7 +1649,7 @@ class ModelParameters(AutoPeakDetection):
         key_1: str,
         key_2: str,
         key_3: str,
-        value_3: Dict[str, Any],
+        value_3: dict[str, Any],
     ) -> None:
         """Define the input parameters for a `params`-dictionary for global fitting.
 
@@ -1712,7 +1708,7 @@ class SolverModels(ModelParameters):
           the `lmfit` function is used.
     """
 
-    def __init__(self, df: pd.DataFrame, args: Dict[str, Any]) -> None:
+    def __init__(self, df: pd.DataFrame, args: dict[str, Any]) -> None:
         """Initialize the solver modes.
 
         Args:
@@ -1726,7 +1722,7 @@ class SolverModels(ModelParameters):
         self.args_global = GlobalFittingAPI(**args).model_dump()
         self.params = self.return_params
 
-    def __call__(self) -> Tuple[Minimizer, Any]:
+    def __call__(self) -> tuple[Minimizer, Any]:
         """Solve the fitting model.
 
         Returns:
@@ -1756,7 +1752,7 @@ class SolverModels(ModelParameters):
 
     @staticmethod
     def solve_local_fitting(
-        params: Dict[str, Parameters],
+        params: dict[str, Parameters],
         x: NDArray[np.float64],
         data: NDArray[np.float64],
     ) -> NDArray[np.float64]:
@@ -1772,7 +1768,7 @@ class SolverModels(ModelParameters):
 
         """
         val = np.zeros(x.shape)
-        peak_kwargs: Dict[Tuple[str, str], Parameters] = defaultdict(dict)
+        peak_kwargs: dict[tuple[str, str], Parameters] = defaultdict(dict)
         for model_name, param_value in params.items():
             _model = model_name.lower()
             ReferenceKeys().model_check(model=_model)
@@ -1789,7 +1785,7 @@ class SolverModels(ModelParameters):
 
     @staticmethod
     def solve_global_fitting(
-        params: Dict[str, Parameters],
+        params: dict[str, Parameters],
         x: NDArray[np.float64],
         data: NDArray[np.float64],
     ) -> NDArray[np.float64]:
@@ -1819,7 +1815,7 @@ class SolverModels(ModelParameters):
 
         """
         val = np.zeros(data.shape)
-        peak_kwargs: Dict[Tuple[str, str, str], Parameters] = defaultdict(dict)
+        peak_kwargs: dict[tuple[str, str, str], Parameters] = defaultdict(dict)
 
         for model, value in params.items():
             model_lower = model.lower()
@@ -1835,7 +1831,7 @@ class SolverModels(ModelParameters):
 
 
 def calculated_model(
-    params: Dict[str, Parameters],
+    params: dict[str, Parameters],
     x: NDArray[np.float64],
     df: pd.DataFrame,
     global_fit: int,
@@ -1860,7 +1856,7 @@ def calculated_model(
             models.
 
     """
-    peak_kwargs: Dict[Any, Parameters] = defaultdict(dict)
+    peak_kwargs: dict[Any, Parameters] = defaultdict(dict)
 
     for model, value in params.items():
         model_lower = model.lower()

--- a/spectrafit/models/moessbauer.py
+++ b/spectrafit/models/moessbauer.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import warnings
 
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import Optional
 
 import numpy as np
 
@@ -148,7 +146,7 @@ def moessbauer_sextet(
     fwhml: float = 0.25,
     amplitude: float = 1.0,
     center: float = 0.0,
-    angle_theta_phi: Optional[Dict[str, float]] = None,
+    angle_theta_phi: dict[str, float] | None = None,
     quadrupole_shift: float = 0.0,
     background: float = 0.0,
 ) -> NDArray[np.float64]:
@@ -250,7 +248,7 @@ def moessbauer_octet(
     center: float = 0.0,
     efg_vzz: float = 1e21,
     efg_eta: float = 0.0,
-    angle_theta_phi: Optional[Dict[str, float]] = None,
+    angle_theta_phi: dict[str, float] | None = None,
     temperature: float = 300.0,
     sod_shift: float = 0.0,
     site_fraction: float = 1.0,

--- a/spectrafit/models/test/conftest.py
+++ b/spectrafit/models/test/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Dict
 
 import numpy as np
 import pytest
@@ -46,7 +45,7 @@ def distribution_model_instance() -> DistributionModels:
 
 
 @pytest.fixture
-def moessbauer_singlet_params() -> Dict[str, float]:
+def moessbauer_singlet_params() -> dict[str, float]:
     """Create parameters for testing the Mössbauer singlet model.
 
     Returns:
@@ -62,7 +61,7 @@ def moessbauer_singlet_params() -> Dict[str, float]:
 
 
 @pytest.fixture
-def moessbauer_doublet_params() -> Dict[str, float]:
+def moessbauer_doublet_params() -> dict[str, float]:
     """Create parameters for testing the Mössbauer doublet model.
 
     Returns:
@@ -79,7 +78,7 @@ def moessbauer_doublet_params() -> Dict[str, float]:
 
 
 @pytest.fixture
-def moessbauer_sextet_params() -> Dict[str, float]:
+def moessbauer_sextet_params() -> dict[str, float]:
     """Create parameters for testing the Mössbauer sextet model.
 
     Returns:
@@ -97,7 +96,7 @@ def moessbauer_sextet_params() -> Dict[str, float]:
 
 
 @pytest.fixture
-def moessbauer_octet_params() -> Dict[str, float]:
+def moessbauer_octet_params() -> dict[str, float]:
     """Create parameters for testing the Mössbauer octet model.
 
     Returns:

--- a/spectrafit/models/test/test_builtin.py
+++ b/spectrafit/models/test/test_builtin.py
@@ -9,8 +9,6 @@ from math import sqrt
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -34,7 +32,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-def assert_solver_models(mp: Tuple[Minimizer, Any]) -> None:
+def assert_solver_models(mp: tuple[Minimizer, Any]) -> None:
     """Assert SolverModels."""
     assert isinstance(mp.__str__(), str)
     assert isinstance(mp, tuple)
@@ -94,7 +92,7 @@ class TestNotSupported:
     """Test of not supported models."""
 
     # Using ClassVar per Ruff RUF012 even though mypy complains
-    args: ClassVar[Dict[str, Any]] = {
+    args: ClassVar[dict[str, Any]] = {
         "autopeak": False,
         "column": ["energy", "intensity"],
         "global_": 0,
@@ -180,7 +178,7 @@ class TestModelParametersSolver:
     """Test of model parameters."""
 
     # Using ClassVar per Ruff RUF012 even though mypy complains
-    args: ClassVar[Dict[str, Any]] = {
+    args: ClassVar[dict[str, Any]] = {
         "global_": 0,
         "autopeak": False,
         "column": ["Energy", "Intensity"],
@@ -211,7 +209,7 @@ class TestModelParametersSolver:
             },
         },
     }
-    args_global_1: ClassVar[Dict[str, Any]] = {
+    args_global_1: ClassVar[dict[str, Any]] = {
         "autopeak": False,
         "global_": 1,
         "column": ["Energy"],
@@ -236,7 +234,7 @@ class TestModelParametersSolver:
             },
         },
     }
-    args_global_2: ClassVar[Dict[str, Any]] = {
+    args_global_2: ClassVar[dict[str, Any]] = {
         "autopeak": False,
         "global_": 2,
         "column": ["Energy"],
@@ -334,7 +332,7 @@ class TestModelParametersSolver:
         assert_solver_models(mp)
 
     @pytest.fixture
-    def args_setting(self) -> Dict[str, Any]:
+    def args_setting(self) -> dict[str, Any]:
         """Fixture for args.
 
         Returns:
@@ -619,7 +617,7 @@ class TestModelParametersSolver:
     def test_all_model_local(
         self,
         random_df: pd.DataFrame,
-        args_setting: Dict[str, Any],
+        args_setting: dict[str, Any],
     ) -> None:
         """Test of the AllModel class for local fitting."""
         df = random_df
@@ -635,7 +633,7 @@ class TestModelParametersSolver:
     def test_all_model_global(
         self,
         random_df: pd.DataFrame,
-        args_setting: Dict[str, Any],
+        args_setting: dict[str, Any],
     ) -> None:
         """Test of the AllModel class for global fitting."""
         df = random_df
@@ -676,7 +674,7 @@ class TestAutoPeakDetection:
     @staticmethod
     def assert_isinstance(
         peaks: NDArray[np.float64],
-        properties: Dict[str, Any],
+        properties: dict[str, Any],
     ) -> None:
         """Assert if the peaks and properties are of the correct type."""
         assert isinstance(peaks, np.ndarray)
@@ -721,7 +719,7 @@ class TestAutoPeakDetection:
         data = np.arange(10, dtype=np.float64)
 
         auto = AutoPeakDetection(x=x, data=data, args=args)
-        _val: Tuple[float, float] = auto.estimated_plateau_size
+        _val: tuple[float, float] = auto.estimated_plateau_size
         assert isclose(_val[0], 0.0)
         assert isclose(_val[1], 9.0)
 
@@ -1039,7 +1037,7 @@ class TestModel:
         self,
         x_data: NDArray[np.float64],
         model: str,
-        params: Dict[str, float],
+        params: dict[str, float],
     ) -> None:
         """Test of all distribution models."""
         y_data = getattr(DistributionModels(), model)(x_data, **params)
@@ -1116,7 +1114,7 @@ class TestModel:
         self,
         df_data: pd.DataFrame,
         model: str,
-        params: Dict[str, Dict[Any, Any]],
+        params: dict[str, dict[Any, Any]],
     ) -> None:
         """Test if the model exists."""
         args = {
@@ -1141,7 +1139,7 @@ class TestDefineParametersAuto:
     @pytest.fixture
     def mock_autodetect(
         self,
-    ) -> Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]]:
+    ) -> Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]]:
         """Mock the autodetect method for testing."""
         # Mock positions and properties returned by find_peaks
         positions = np.array([3, 6, 9])
@@ -1151,8 +1149,8 @@ class TestDefineParametersAuto:
         }
 
         def _mock_fn(
-            *args: Tuple[Any, ...],
-        ) -> Tuple[NDArray[Any], Dict[str, NDArray[Any]]]:
+            *args: tuple[Any, ...],
+        ) -> tuple[NDArray[Any], dict[str, NDArray[Any]]]:
             return positions, properties
 
         return _mock_fn
@@ -1171,7 +1169,7 @@ class TestDefineParametersAuto:
     def test_gaussian(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Test auto-detection of Gaussian peaks."""
@@ -1194,7 +1192,7 @@ class TestDefineParametersAuto:
     def test_lorentzian(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {
@@ -1215,7 +1213,7 @@ class TestDefineParametersAuto:
     def test_voigt(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {
@@ -1236,7 +1234,7 @@ class TestDefineParametersAuto:
     def test_pseudovoigt(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {
@@ -1258,7 +1256,7 @@ class TestDefineParametersAuto:
     def test_orcagaussian(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {
@@ -1279,7 +1277,7 @@ class TestDefineParametersAuto:
     def test_default_gaussian_if_no_modeltype(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {
@@ -1297,7 +1295,7 @@ class TestDefineParametersAuto:
     def test_invalid_auto_model_raises(
         self,
         mock_local_df: pd.DataFrame,
-        mock_autodetect: Callable[..., Tuple[NDArray[Any], Dict[str, NDArray[Any]]]],
+        mock_autodetect: Callable[..., tuple[NDArray[Any], dict[str, NDArray[Any]]]],
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         args = {

--- a/spectrafit/models/test/test_conftest.py
+++ b/spectrafit/models/test/test_conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Dict
 
 import numpy as np
 
@@ -42,7 +41,7 @@ def test_energy_data(energy_data: NDArray[np.float64]) -> None:
     assert np.isclose(energy_data[-1], 10.0, rtol=1e-10)
 
 
-def test_moessbauer_singlet_params(moessbauer_singlet_params: Dict[str, float]) -> None:
+def test_moessbauer_singlet_params(moessbauer_singlet_params: dict[str, float]) -> None:
     """Test that moessbauer_singlet_params fixture returns expected dictionary.
 
     Args:
@@ -63,7 +62,7 @@ def test_moessbauer_singlet_params(moessbauer_singlet_params: Dict[str, float]) 
     assert np.isclose(moessbauer_singlet_params["isomer_shift"], 0.0, rtol=1e-10)
 
 
-def test_moessbauer_doublet_params(moessbauer_doublet_params: Dict[str, float]) -> None:
+def test_moessbauer_doublet_params(moessbauer_doublet_params: dict[str, float]) -> None:
     """Test that moessbauer_doublet_params fixture returns expected dictionary.
 
     Args:
@@ -91,7 +90,7 @@ def test_moessbauer_doublet_params(moessbauer_doublet_params: Dict[str, float]) 
     )
 
 
-def test_moessbauer_sextet_params(moessbauer_sextet_params: Dict[str, float]) -> None:
+def test_moessbauer_sextet_params(moessbauer_sextet_params: dict[str, float]) -> None:
     """Test that moessbauer_sextet_params fixture returns expected dictionary.
 
     Args:
@@ -118,7 +117,7 @@ def test_moessbauer_sextet_params(moessbauer_sextet_params: Dict[str, float]) ->
     assert np.isclose(moessbauer_sextet_params["quadrupole_shift"], 0.0, rtol=1e-10)
 
 
-def test_moessbauer_octet_params(moessbauer_octet_params: Dict[str, float]) -> None:
+def test_moessbauer_octet_params(moessbauer_octet_params: dict[str, float]) -> None:
     """Test that moessbauer_octet_params fixture returns expected dictionary.
 
     Args:

--- a/spectrafit/models/test/test_moessbauer.py
+++ b/spectrafit/models/test/test_moessbauer.py
@@ -7,8 +7,6 @@ and API integration tests. It covers singlets, doublets, sextets and octets.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from typing import Dict
-from typing import Union
 
 import numpy as np
 import pytest
@@ -643,7 +641,7 @@ def patch_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
     ],
 )
 def test_moessbauer_octet_happy_and_edge_cases(
-    params: Dict[str, Union[float, NDArray[np.float64]]],
+    params: dict[str, float | NDArray[np.float64]],
     expected_shape: tuple[int, ...],
     expected_type: type,
     expected_min: float,

--- a/spectrafit/plotting.py
+++ b/spectrafit/plotting.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import Optional
 
 import matplotlib.font_manager
 import matplotlib.pyplot as plt
@@ -37,7 +35,7 @@ color = sns.color_palette("Paired")
 class PlotSpectra:
     """Plotting of the fit results."""
 
-    def __init__(self, df: pd.DataFrame, args: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, df: pd.DataFrame, args: dict[str, Any] | None = None) -> None:
         """Initialize the PlotSpectra class.
 
         Args:

--- a/spectrafit/plugins/color_schemas.py
+++ b/spectrafit/plugins/color_schemas.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from spectrafit.api.notebook_model import ColorAPI
 from spectrafit.api.notebook_model import FontAPI
 
@@ -37,8 +35,8 @@ class DraculaColor(ColorAPI):
     intensity: str = "#bd93f9"
     residual: str = "#ff5555"
     fit: str = "#50fa7b"
-    bars: List[str] = ["#803C62", "#FFC4E6", "#FF79C6", "#806273", "#CC609D"]
-    lines: List[str] = ["#805C36", "#FFDCB8", "#FFB86C", "#806E5C", "#CC9356"]
+    bars: list[str] = ["#803C62", "#FFC4E6", "#FF79C6", "#806273", "#CC609D"]
+    lines: list[str] = ["#805C36", "#FFDCB8", "#FFB86C", "#806E5C", "#CC9356"]
     components: str = "#ff79c6"
     paper: str = "#282a36"
     plot: str = "#282a36"
@@ -77,8 +75,8 @@ class ColorBlindColor(ColorAPI):
     intensity: str = "#1f77b4"
     residual: str = "#ff7f0e"
     fit: str = "#d62728"
-    bars: List[str] = ["#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f"]
-    lines: List[str] = ["#8c564b", "#e377c2", "#7f7f7f", "#d62728", "#9467bd"]
+    bars: list[str] = ["#d62728", "#9467bd", "#8c564b", "#e377c2", "#7f7f7f"]
+    lines: list[str] = ["#8c564b", "#e377c2", "#7f7f7f", "#d62728", "#9467bd"]
     components: str = "#2ca02c"
     paper: str = "#ffffff"
     plot: str = "#ffffff"
@@ -104,8 +102,8 @@ class MoonAkiColor(ColorAPI):
     intensity: str = "#f92672"
     residual: str = "#fd971f"
     fit: str = "#a6e22e"
-    bars: List[str] = ["#66d9ef", "#ae81ff", "#f92672", "#a6e22e", "#fd971f"]
-    lines: List[str] = ["#f92672", "#a6e22e", "#fd971f", "#66d9ef", "#ae81ff"]
+    bars: list[str] = ["#66d9ef", "#ae81ff", "#f92672", "#a6e22e", "#fd971f"]
+    lines: list[str] = ["#f92672", "#a6e22e", "#fd971f", "#66d9ef", "#ae81ff"]
     components: str = "#ae81ff"
     paper: str = "#272822"
     plot: str = "#272822"
@@ -134,8 +132,8 @@ class DevOpsDarkColor(ColorAPI):
     intensity: str = "#1e4f8a"
     residual: str = "#d73a49"
     fit: str = "#22863a"
-    bars: List[str] = ["#005cc5", "#6f42c1", "#d73a49", "#22863a", "#d73a49"]
-    lines: List[str] = ["#d73a49", "#22863a", "#d73a49", "#005cc5", "#6f42c1"]
+    bars: list[str] = ["#005cc5", "#6f42c1", "#d73a49", "#22863a", "#d73a49"]
+    lines: list[str] = ["#d73a49", "#22863a", "#d73a49", "#005cc5", "#6f42c1"]
     components: str = "#d73a49"
     paper: str = "#0d1117"
     plot: str = "#0d1117"
@@ -167,8 +165,8 @@ class DevOpsLightColor(ColorAPI):
     intensity: str = "#1e4f8a"
     residual: str = "#d73a49"
     fit: str = "#d73a49"
-    bars: List[str] = ["#005cc5", "#6f42c1", "#d73a49", "#22863a", "#d73a49"]
-    lines: List[str] = ["#d73a49", "#22863a", "#d73a49", "#005cc5", "#6f42c1"]
+    bars: list[str] = ["#005cc5", "#6f42c1", "#d73a49", "#22863a", "#d73a49"]
+    lines: list[str] = ["#d73a49", "#22863a", "#d73a49", "#005cc5", "#6f42c1"]
     components: str = "#22863a"
     paper: str = "#ffffff"
     plot: str = "#ffffff"

--- a/spectrafit/plugins/converter.py
+++ b/spectrafit/plugins/converter.py
@@ -6,11 +6,10 @@ from abc import ABC
 from abc import abstractmethod
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import MutableMapping
 
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
     from pathlib import Path
 
 
@@ -30,7 +29,7 @@ class Converter(ABC):
     """
 
     @abstractmethod
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:

--- a/spectrafit/plugins/data_converter.py
+++ b/spectrafit/plugins/data_converter.py
@@ -7,11 +7,8 @@ import re
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import MutableMapping
-from typing import Optional
 
 import pandas as pd
 
@@ -19,7 +16,11 @@ from spectrafit.api.file_model import DataFileAPI
 from spectrafit.plugins.converter import Converter
 
 
-def get_athena_column(fname: Path, comment: str = "#") -> Optional[List[str]]:
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
+
+def get_athena_column(fname: Path, comment: str = "#") -> list[str] | None:
     """Get the header of the file.
 
     Args:
@@ -92,7 +93,7 @@ class DataConverter(Converter):
         `DataConverter` class can be also used in the Jupyter notebook.
     """
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:

--- a/spectrafit/plugins/file_converter.py
+++ b/spectrafit/plugins/file_converter.py
@@ -6,16 +6,19 @@ import argparse
 import json
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import MutableMapping
 
 import tomli_w
 import yaml
 
 from spectrafit.plugins.converter import Converter
 from spectrafit.tools import read_input_file
+
+
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
 
 
 class FileConverter(Converter):
@@ -36,7 +39,7 @@ class FileConverter(Converter):
 
     choices: ClassVar[set[str]] = {"json", "yaml", "yml", "toml", "lock"}
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:

--- a/spectrafit/plugins/notebook.py
+++ b/spectrafit/plugins/notebook.py
@@ -5,11 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -61,7 +56,7 @@ MIN_DATAFRAME_COLUMNS = 2  # Minimum number of columns required in a dataframe
 class DataFrameDisplay:
     """Class for displaying a dataframe in different ways."""
 
-    def df_display(self, df: pd.DataFrame, mode: Optional[str] = None) -> Optional[Any]:
+    def df_display(self, df: pd.DataFrame, mode: str | None = None) -> Any | None:
         """Call the DataframeDisplay class.
 
         !!! info "About `df_display`"
@@ -163,7 +158,7 @@ class DataFramePlot:
         self,
         args_plot: PlotAPI,
         df_1: pd.DataFrame,
-        df_2: Optional[pd.DataFrame] = None,
+        df_2: pd.DataFrame | None = None,
     ) -> None:
         """Plot two dataframes.
 
@@ -392,8 +387,8 @@ class DataFramePlot:
         self,
         args_plot: PlotAPI,
         df_metric: pd.DataFrame,
-        bar_criteria: Union[str, List[str]],
-        line_criteria: Union[str, List[str]],
+        bar_criteria: str | list[str],
+        line_criteria: str | list[str],
     ) -> None:
         """Plot the metric according to the PlotAPI arguments.
 
@@ -504,7 +499,7 @@ class DataFramePlot:
         return fig
 
     @staticmethod
-    def title_text(name: str, unit: Optional[str] = None) -> str:
+    def title_text(name: str, unit: str | None = None) -> str:
         """Return the title text.
 
         Args:
@@ -517,7 +512,7 @@ class DataFramePlot:
         """
         return f"{name} [{unit}]" if unit else name
 
-    def get_minor(self, args_plot: PlotAPI) -> Dict[str, Union[str, bool]]:
+    def get_minor(self, args_plot: PlotAPI) -> dict[str, str | bool]:
         """Get the minor axis arguments.
 
         Args:
@@ -557,7 +552,7 @@ class ExportResults:
             index=False,
         )
 
-    def export_report(self, report: Dict[Any, Any], args: FnameAPI) -> None:
+    def export_report(self, report: dict[Any, Any], args: FnameAPI) -> None:
         """Export the results as toml file.
 
         Args:
@@ -578,8 +573,8 @@ class ExportResults:
     def fname2path(
         fname: str,
         suffix: str,
-        prefix: Optional[str] = None,
-        folder: Optional[str] = None,
+        prefix: str | None = None,
+        folder: str | None = None,
     ) -> Path:
         """Translate string to Path object.
 
@@ -607,7 +602,7 @@ class ExportResults:
 class SolverResults:
     """Class for storing the results of the solver."""
 
-    def __init__(self, args_out: Dict[str, Any]) -> None:
+    def __init__(self, args_out: dict[str, Any]) -> None:
         """Initialize the SolverResults class.
 
         Args:
@@ -617,7 +612,7 @@ class SolverResults:
         self.args_out = args_out
 
     @property
-    def settings_global_fitting(self) -> Union[bool, int]:
+    def settings_global_fitting(self) -> bool | int:
         """Global fitting settings.
 
         Returns:
@@ -627,7 +622,7 @@ class SolverResults:
         return self.args_out["global_"]
 
     @property
-    def settings_configurations(self) -> Dict[str, Any]:
+    def settings_configurations(self) -> dict[str, Any]:
         """Configure settings.
 
         Returns:
@@ -637,7 +632,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["configurations"]
 
     @property
-    def get_gof(self) -> Dict[str, float]:
+    def get_gof(self) -> dict[str, float]:
         """Get the goodness of fit values.
 
         Returns:
@@ -647,7 +642,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["statistics"]
 
     @property
-    def get_variables(self) -> Dict[str, Dict[str, float]]:
+    def get_variables(self) -> dict[str, dict[str, float]]:
         """Get the variables of the fit.
 
         Returns:
@@ -657,7 +652,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["variables"]
 
     @property
-    def get_errorbars(self) -> Dict[str, float]:
+    def get_errorbars(self) -> dict[str, float]:
         """Get the comments about the error bars of fit values.
 
         Returns:
@@ -667,7 +662,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["errorbars"]
 
     @property
-    def get_component_correlation(self) -> Dict[str, Any]:
+    def get_component_correlation(self) -> dict[str, Any]:
         """Get the linear correlation of the components.
 
         Returns:
@@ -677,7 +672,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["correlations"]
 
     @property
-    def get_covariance_matrix(self) -> Dict[str, Any]:
+    def get_covariance_matrix(self) -> dict[str, Any]:
         """Get the covariance matrix.
 
         Returns:
@@ -687,7 +682,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["covariance_matrix"]
 
     @property
-    def get_regression_metrics(self) -> Dict[str, Any]:
+    def get_regression_metrics(self) -> dict[str, Any]:
         """Get the regression metrics.
 
         Returns:
@@ -697,7 +692,7 @@ class SolverResults:
         return self.args_out["regression_metrics"]
 
     @property
-    def get_descriptive_statistic(self) -> Dict[str, Any]:
+    def get_descriptive_statistic(self) -> dict[str, Any]:
         """Get the descriptive statistic.
 
         Returns:
@@ -708,7 +703,7 @@ class SolverResults:
         return self.args_out["descriptive_statistic"]
 
     @property
-    def get_linear_correlation(self) -> Dict[str, Any]:
+    def get_linear_correlation(self) -> dict[str, Any]:
         """Get the linear correlation.
 
         Returns:
@@ -719,7 +714,7 @@ class SolverResults:
         return self.args_out["linear_correlation"]
 
     @property
-    def get_computational(self) -> Dict[str, Any]:
+    def get_computational(self) -> dict[str, Any]:
         """Get the computational time.
 
         Returns:
@@ -729,7 +724,7 @@ class SolverResults:
         return self.args_out["fit_insights"]["computational"]
 
     @property
-    def settings_conf_interval(self) -> Union[bool, Dict[str, Any]]:
+    def settings_conf_interval(self) -> bool | dict[str, Any]:
         """Confidence interval settings.
 
         Returns:
@@ -744,7 +739,7 @@ class SolverResults:
         return self.args_out["conf_interval"]
 
     @property
-    def get_confidence_interval(self) -> Dict[Any, Any]:
+    def get_confidence_interval(self) -> dict[Any, Any]:
         """Get the confidence interval.
 
         Returns:
@@ -789,14 +784,14 @@ class ExportReport(SolverResults):
     def __init__(
         self,
         description: DescriptionAPI,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
         pre_processing: DataPreProcessingAPI,
         settings_solver_models: SolverModelsAPI,
         fname: FnameAPI,
-        args_out: Dict[str, Any],
+        args_out: dict[str, Any],
         df_org: pd.DataFrame,
         df_fit: pd.DataFrame,
-        df_pre: Optional[pd.DataFrame] = None,
+        df_pre: pd.DataFrame | None = None,
     ) -> None:
         """Initialize the ExportReport class.
 
@@ -882,7 +877,7 @@ class ExportReport(SolverResults):
         """
         return OutputAPI(df_org=self.df_org, df_fit=self.df_fit, df_pre=self.df_pre)
 
-    def __call__(self) -> Dict[str, Any]:
+    def __call__(self) -> dict[str, Any]:
         """Get the complete report as dictionary.
 
         !!! info "About the report and `exclude_none_dictionary`"
@@ -910,42 +905,42 @@ class ExportReport(SolverResults):
 class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
     """Jupyter Notebook plugin for SpectraFit."""
 
-    args: Dict[str, Any]
-    global_: Union[bool, int] = False
+    args: dict[str, Any]
+    global_: bool | int = False
     autopeak: bool = False
     df_fit: pd.DataFrame
     df_pre: pd.DataFrame = pd.DataFrame()
     df_metric: pd.DataFrame = pd.DataFrame()
     df_peaks: pd.DataFrame = pd.DataFrame()
-    initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]]
+    initial_model: list[dict[str, dict[str, dict[str, Any]]]]
 
     def __init__(  # noqa: C901
         self,
         df: pd.DataFrame,
         x_column: str,
-        y_column: Union[str, List[str]],
+        y_column: str | list[str],
         oversampling: bool = False,
         smooth: int = 0,
         shift: float = 0,
-        energy_start: Optional[float] = None,
-        energy_stop: Optional[float] = None,
-        title: Optional[str] = None,
-        xaxis_title: Optional[XAxisAPI] = None,
-        yaxis_title: Optional[YAxisAPI] = None,
-        residual_title: Optional[ResidualAPI] = None,
-        metric_title: Optional[MetricAPI] = None,
-        run_title: Optional[RunAPI] = None,
+        energy_start: float | None = None,
+        energy_stop: float | None = None,
+        title: str | None = None,
+        xaxis_title: XAxisAPI | None = None,
+        yaxis_title: YAxisAPI | None = None,
+        residual_title: ResidualAPI | None = None,
+        metric_title: MetricAPI | None = None,
+        run_title: RunAPI | None = None,
         legend_title: str = "Spectra",
         show_legend: bool = True,
-        legend: Optional[LegendAPI] = None,
-        font: Optional[FontAPI] = None,
+        legend: LegendAPI | None = None,
+        font: FontAPI | None = None,
         minor_ticks: bool = True,
-        color: Optional[ColorAPI] = None,
-        grid: Optional[GridAPI] = None,
-        size: Tuple[int, Tuple[int, int]] = (800, (600, 300)),
+        color: ColorAPI | None = None,
+        grid: GridAPI | None = None,
+        size: tuple[int, tuple[int, int]] = (800, (600, 300)),
         fname: str = "results",
-        folder: Optional[str] = None,
-        description: Optional[DescriptionAPI] = None,
+        folder: str | None = None,
+        description: DescriptionAPI | None = None,
     ) -> None:
         """Initialize the SpectraFitNotebook class.
 
@@ -1097,7 +1092,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         self.export_args_out = FnameAPI(fname=fname, folder=folder, suffix="lock")
 
         self.settings_solver_models: SolverModelsAPI = SolverModelsAPI()
-        self.pre_statistic: Dict[str, Any] = {}
+        self.pre_statistic: dict[str, Any] = {}
 
     @property
     def pre_process(self) -> None:
@@ -1110,7 +1105,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         self.df_pre = self.df.copy()
 
     @property
-    def return_pre_statistic(self) -> Dict[str, Any]:
+    def return_pre_statistic(self) -> dict[str, Any]:
         """Return the pre-processing statistic."""
         return self.pre_statistic
 
@@ -1120,7 +1115,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         return self.df_org
 
     @property
-    def return_df_pre(self) -> Union[pd.DataFrame, None]:
+    def return_df_pre(self) -> pd.DataFrame | None:
         """Return the pre-processed dataframe."""
         return self.df_pre
 
@@ -1201,8 +1196,8 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
 
     def plot_current_metric(
         self,
-        bar_criteria: Optional[Union[str, List[str]]] = None,
-        line_criteria: Optional[Union[str, List[str]]] = None,
+        bar_criteria: str | list[str] | None = None,
+        line_criteria: str | list[str] | None = None,
     ) -> None:
         """Plot the current metric.
 
@@ -1251,16 +1246,16 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
 
     def solver_model(
         self,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
         *,
         show_plot: bool = True,
         show_metric: bool = True,
         show_df: bool = False,
         show_peaks: bool = False,
-        conf_interval: Union[bool, Dict[str, Any]] = False,
-        bar_criteria: Optional[Union[str, List[str]]] = None,
-        line_criteria: Optional[Union[str, List[str]]] = None,
-        solver_settings: Optional[Dict[str, Any]] = None,
+        conf_interval: bool | dict[str, Any] = False,
+        bar_criteria: str | list[str] | None = None,
+        line_criteria: str | list[str] | None = None,
+        solver_settings: dict[str, Any] | None = None,
     ) -> None:
         """Solves the fit problem based on the proposed model.
 
@@ -1378,7 +1373,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
             ignore_index=True,
         )
 
-    def display_fit_df(self, mode: Optional[str] = "regular") -> None:
+    def display_fit_df(self, mode: str | None = "regular") -> None:
         """Display the fit dataframe.
 
         Args:
@@ -1387,7 +1382,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         """
         self.df_display(df=self.df_fit, mode=mode)
 
-    def display_preprocessed_df(self, mode: Optional[str] = "regular") -> None:
+    def display_preprocessed_df(self, mode: str | None = "regular") -> None:
         """Display the preprocessed dataframe.
 
         Args:
@@ -1396,7 +1391,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         """
         self.df_display(df=self.df_pre, mode=mode)
 
-    def display_original_df(self, mode: Optional[str] = "regular") -> None:
+    def display_original_df(self, mode: str | None = "regular") -> None:
         """Display the original dataframe.
 
         Args:
@@ -1405,7 +1400,7 @@ class SpectraFitNotebook(DataFramePlot, DataFrameDisplay, ExportResults):
         """
         self.df_display(df=self.df_org, mode=mode)
 
-    def display_current_df(self, mode: Optional[str] = "regular") -> None:
+    def display_current_df(self, mode: str | None = "regular") -> None:
         """Display the current dataframe.
 
         Args:

--- a/spectrafit/plugins/pkl_converter.py
+++ b/spectrafit/plugins/pkl_converter.py
@@ -9,9 +9,6 @@ import pickle
 from pathlib import Path
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import List
-from typing import Optional
 
 import numpy as np
 
@@ -55,7 +52,7 @@ class ExportData:
         ```
     """
 
-    def __init__(self, data: Dict[str, Any], fname: Path, export_format: str) -> None:
+    def __init__(self, data: dict[str, Any], fname: Path, export_format: str) -> None:
         """Export the data to a file.
 
         Args:
@@ -93,7 +90,7 @@ class ExportData:
                 pickle.dump(self.data, f)
 
     @staticmethod
-    def numpy2list(data: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def numpy2list(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Convert the arrays of list dictionaries to a list of dictionaries with list.
 
         Args:
@@ -138,7 +135,7 @@ class PklConverter(Converter):
     choices_fformat: ClassVar[set[str]] = {"latin1", "utf-8", "utf-16", "utf-32"}
     choices_export: ClassVar[set[str]] = {"npy", "npz", "pkl", "pkl.gz"}
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:
@@ -175,7 +172,7 @@ class PklConverter(Converter):
         return vars(parser.parse_args())
 
     @staticmethod
-    def convert(infile: Path, file_format: str) -> Dict[str, Any]:
+    def convert(infile: Path, file_format: str) -> dict[str, Any]:
         """Convert the input file to the output file.
 
         Args:
@@ -188,9 +185,9 @@ class PklConverter(Converter):
         """
 
         def _convert(
-            data_values: Dict[str, Any],
-            _key: Optional[List[str]] = None,
-        ) -> List[Dict[str, Any]]:
+            data_values: dict[str, Any],
+            _key: list[str] | None = None,
+        ) -> list[dict[str, Any]]:
             """Convert the data to a list of dictionaries.
 
             The new key is the old key plus all the subkeys. The new value is the

--- a/spectrafit/plugins/pkl_visualizer.py
+++ b/spectrafit/plugins/pkl_visualizer.py
@@ -8,8 +8,6 @@ import json
 from pathlib import Path
 from typing import Any
 from typing import ClassVar
-from typing import Dict
-from typing import Union
 
 import matplotlib.pyplot as plt
 import networkx as nx
@@ -32,7 +30,7 @@ class PklVisualizer(Converter):
     choices_fformat: ClassVar[set[str]] = {"latin1", "utf-8", "utf-16", "utf-32"}
     choices_export: ClassVar[set[str]] = {"png", "pdf", "jpg", "jpeg"}
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:
@@ -70,7 +68,7 @@ class PklVisualizer(Converter):
         return vars(parser.parse_args())
 
     @staticmethod
-    def convert(infile: Path, file_format: str) -> Dict[str, Any]:
+    def convert(infile: Path, file_format: str) -> dict[str, Any]:
         """Convert the input file to the output file.
 
         Args:
@@ -127,7 +125,7 @@ class PklVisualizer(Converter):
         with pure_fname(fname).with_suffix(".json").open("w+", encoding="utf-8") as f:
             json.dump(data, f, indent=4)
 
-    def get_type(self, value: Any) -> Union[Dict[str, Any], str]:
+    def get_type(self, value: Any) -> dict[str, Any] | str:
         """Get the type of the value.
 
         Args:
@@ -143,7 +141,7 @@ class PklVisualizer(Converter):
             return f"{type(value)} of shape {value.shape}"
         return str(type(value))
 
-    def add_nodes(self, graph: nx.DiGraph, data_dict: Dict[str, Any]) -> None:
+    def add_nodes(self, graph: nx.DiGraph, data_dict: dict[str, Any]) -> None:
         """Add nodes to the graph.
 
         Args:
@@ -170,7 +168,7 @@ class PklVisualizer(Converter):
                 graph.add_node(value)
                 graph.add_edge(key, value)
 
-    def create_graph(self, fname: Path, data_dict: Dict[str, Any]) -> nx.DiGraph:
+    def create_graph(self, fname: Path, data_dict: dict[str, Any]) -> nx.DiGraph:
         """Create the graph.
 
         Args:

--- a/spectrafit/plugins/pptx_converter.py
+++ b/spectrafit/plugins/pptx_converter.py
@@ -7,10 +7,6 @@ import argparse
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import MutableMapping
-from typing import Optional
-from typing import Type
 
 import tomli
 
@@ -26,13 +22,15 @@ from spectrafit.plugins.converter import Converter
 
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     import pandas as pd
 
 
 class PPTXElements:
     """Generate a powerpoint presentation from a the spectrafit output."""
 
-    def __init__(self, slide: Type[Any]) -> None:
+    def __init__(self, slide: type[Any]) -> None:
         """Create a powerpoint presentation from a the spectrafit output.
 
         Args:
@@ -45,7 +43,7 @@ class PPTXElements:
         self,
         text: str,
         position: PPTXPositionAPI,
-        font_size: Optional[Pt] = None,
+        font_size: Pt | None = None,
     ) -> None:
         """Create a textbox from the input file.
 
@@ -112,7 +110,7 @@ class PPTXElements:
         index_hidden: bool,
         text: str,
         position_textbox: PPTXPositionAPI,
-        font_size: Optional[Pt] = None,
+        font_size: Pt | None = None,
     ) -> None:
         """Create a table from the input file.
 
@@ -201,7 +199,7 @@ class PPTXElements:
         text: str,
         position_logo: PPTXPositionAPI,
         position_text: PPTXPositionAPI,
-        font_size: Optional[Pt] = None,
+        font_size: Pt | None = None,
     ) -> None:
         """Create a credit for spectrafit.
 
@@ -384,7 +382,7 @@ class PPTXConverter(Converter):
 
     pixel_size = PPTXLayoutAPI.pptx_formats.keys()
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:

--- a/spectrafit/plugins/rixs_converter.py
+++ b/spectrafit/plugins/rixs_converter.py
@@ -6,9 +6,8 @@ import argparse
 import json
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import MutableMapping
 
 import numpy as np
 import tomli_w
@@ -19,6 +18,8 @@ from spectrafit.tools import pkl2any
 from spectrafit.tools import pure_fname
 
 
+if TYPE_CHECKING:
+    from collections.abc import MutableMapping
 choices_fformat = {"latin1", "utf-8", "utf-16", "utf-32"}
 choices_export = {"json", "toml", "lock", "npy", "npz"}
 choices_mode = {"sum", "mean"}
@@ -27,7 +28,7 @@ choices_mode = {"sum", "mean"}
 class RIXSConverter(Converter):
     """Convert raw pickle data into JSON, TOML, or numpy formats."""
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Retrieve command-line arguments.
 
         Returns:

--- a/spectrafit/plugins/rixs_visualizer.py
+++ b/spectrafit/plugins/rixs_visualizer.py
@@ -9,10 +9,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 import dash
 import dash_bootstrap_components as dbc
@@ -59,10 +55,10 @@ class RIXSFigure:
         incident_energy: NDArray[np.float64],
         emission_energy: NDArray[np.float64],
         rixs_map: NDArray[np.float64],
-        size: Optional[SizeRatioAPI] = None,
-        x_axis: Optional[XAxisAPI] = None,
-        y_axis: Optional[YAxisAPI] = None,
-        z_axis: Optional[ZAxisAPI] = None,
+        size: SizeRatioAPI | None = None,
+        x_axis: XAxisAPI | None = None,
+        y_axis: YAxisAPI | None = None,
+        z_axis: ZAxisAPI | None = None,
     ) -> None:
         """Initialize the RIXS figure.
 
@@ -122,7 +118,7 @@ class RIXSFigure:
         self,
         colorscale: str = "Viridis",
         opacity: float = 0.9,
-        template: Optional[str] = None,
+        template: str | None = None,
     ) -> go.Figure:
         """Create the RIXS figure.
 
@@ -188,7 +184,7 @@ class RIXSFigure:
         self,
         x: NDArray[np.float64],
         y: NDArray[np.float64],
-        template: Optional[str] = None,
+        template: str | None = None,
     ) -> go.Figure:
         """Create the XES figure.
 
@@ -227,7 +223,7 @@ class RIXSFigure:
         self,
         x: NDArray[np.float64],
         y: NDArray[np.float64],
-        template: Optional[str] = None,
+        template: str | None = None,
     ) -> go.Figure:
         """Create the XAS figure.
 
@@ -285,9 +281,9 @@ class RIXSApp(RIXSFigure):  # pragma: no cover
         incident_energy: NDArray[np.float64],
         emission_energy: NDArray[np.float64],
         rixs_map: NDArray[np.float64],
-        size: Optional[SizeRatioAPI] = None,
-        main_title: Optional[MainTitleAPI] = None,
-        fdir: Optional[Path] = None,
+        size: SizeRatioAPI | None = None,
+        main_title: MainTitleAPI | None = None,
+        fdir: Path | None = None,
         mode: str = "server",
         jupyter_dash: bool = False,
         port: int = 8050,
@@ -425,7 +421,7 @@ class RIXSApp(RIXSFigure):  # pragma: no cover
             ),
         )
 
-    def pre_body(self) -> Tuple[html.Div, html.Div, html.Div]:
+    def pre_body(self) -> tuple[html.Div, html.Div, html.Div]:
         """Create the body.
 
         Returns:
@@ -573,12 +569,12 @@ class RIXSApp(RIXSFigure):  # pragma: no cover
             ],
         )
         def update_hover_data(
-            hoverData: Dict[str, List[Dict[str, float]]],
-            clickData: Dict[str, List[Dict[str, float]]],
+            hoverData: dict[str, list[dict[str, float]]],
+            clickData: dict[str, list[dict[str, float]]],
             colorscale: str,
             opacity: float,
             theme: str,
-        ) -> Tuple[go.Figure, go.Figure, go.Figure]:
+        ) -> tuple[go.Figure, go.Figure, go.Figure]:
             if hoverData is None:
                 return (
                     self.create_xas(
@@ -647,7 +643,7 @@ class RIXSApp(RIXSFigure):  # pragma: no cover
 class RIXSVisualizer:
     """RIXS Visualizer. This class is used to visualize RIXS data."""
 
-    def get_args(self) -> Dict[str, Any]:
+    def get_args(self) -> dict[str, Any]:
         """Get the arguments from the command line.
 
         Returns:

--- a/spectrafit/plugins/test/test_color_schemas.py
+++ b/spectrafit/plugins/test/test_color_schemas.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Tuple
-from typing import Type
-
 import pytest
 
 from spectrafit.api.notebook_model import ColorAPI
@@ -60,7 +57,7 @@ def test_dracula_font() -> None:
         (ColorBlindColor, ColorBlindFont),
     ],
 )
-def test_color_schemas(color_font: Tuple[Type[ColorAPI], Type[FontAPI]]) -> None:
+def test_color_schemas(color_font: tuple[type[ColorAPI], type[FontAPI]]) -> None:
     """Test the color schemas."""
     color_schema, font_schema = color_font
     color = color_schema()

--- a/spectrafit/plugins/test/test_converter.py
+++ b/spectrafit/plugins/test/test_converter.py
@@ -11,9 +11,7 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
 from typing import Literal
-from typing import Tuple
 
 import numpy as np
 import pandas as pd
@@ -415,7 +413,7 @@ class TestDataConverter:
 
 
 @pytest.fixture(autouse=True, name="tmp_file_dict")
-def tmp_file_dict() -> Dict[str, Dict[str, NDArray[Any]]]:
+def tmp_file_dict() -> dict[str, dict[str, NDArray[Any]]]:
     """Create temporary file with pickle data."""
     return {
         "level_1": {
@@ -434,7 +432,7 @@ def tmp_file_dict() -> Dict[str, Dict[str, NDArray[Any]]]:
 
 
 @pytest.fixture(autouse=True, name="tmp_file_nested_dict")
-def tmp_file_nested_dict() -> Dict[str, Dict[str, Any]]:
+def tmp_file_nested_dict() -> dict[str, dict[str, Any]]:
     """Create temporary file with nested pickle data."""
     return {
         "level_4": {
@@ -457,7 +455,7 @@ def tmp_file_nested_dict() -> Dict[str, Dict[str, Any]]:
 @pytest.fixture(autouse=True, name="tmp_pkl_gz_file")
 def tmp_pkl_gz_file(
     tmp_path: Path,
-    tmp_file_dict: Dict[str, Dict[str, NDArray[np.float64]]],
+    tmp_file_dict: dict[str, dict[str, NDArray[np.float64]]],
 ) -> Path:
     """Create temporary file with pickle data.
 
@@ -478,7 +476,7 @@ def tmp_pkl_gz_file(
 @pytest.fixture(autouse=True, name="tmp_file_pkl")
 def tmp_file_pkl(
     tmp_path: Path,
-    tmp_file_dict: Dict[str, Dict[str, NDArray[np.float64]]],
+    tmp_file_dict: dict[str, dict[str, NDArray[np.float64]]],
 ) -> Path:
     """Create temporary file with pickle data.
 
@@ -499,7 +497,7 @@ def tmp_file_pkl(
 @pytest.fixture(autouse=True, name="tmp_file_pkl_gz")
 def tmp_file_pkl_gz(
     tmp_path: Path,
-    tmp_file_dict: Dict[str, Dict[str, NDArray[np.float64]]],
+    tmp_file_dict: dict[str, dict[str, NDArray[np.float64]]],
 ) -> Path:
     """Create temporary file with pickle data.
 
@@ -520,7 +518,7 @@ def tmp_file_pkl_gz(
 @pytest.fixture(autouse=True, name="tmp_file_pkl_nested")
 def tmp_file_pkl_nested(
     tmp_path: Path,
-    tmp_file_nested_dict: Dict[str, Dict[str, Any]],
+    tmp_file_nested_dict: dict[str, dict[str, Any]],
 ) -> Path:
     """Create temporary file with nested pickle data.
 
@@ -549,7 +547,7 @@ class TestPklConverter:
     def test_export_data(
         self,
         tmp_path: Path,
-        tmp_file_dict: Dict[str, Dict[str, NDArray[np.float64]]],
+        tmp_file_dict: dict[str, dict[str, NDArray[np.float64]]],
         export_format: str,
     ) -> None:
         """Test export data.
@@ -593,7 +591,7 @@ class TestPklConverter:
 
     def test_numpy2list(
         self,
-        tmp_file_dict: Dict[str, Dict[str, NDArray[np.float64]]],
+        tmp_file_dict: dict[str, dict[str, NDArray[np.float64]]],
     ) -> None:
         """Test numpy2list.
 
@@ -660,7 +658,7 @@ class TestPklConverter:
     def test_pkl_converter_nested(
         self,
         tmp_path: Path,
-        tmp_file_nested_dict: Dict[str, Any],
+        tmp_file_nested_dict: dict[str, Any],
     ) -> None:
         """Test pickle converter for nested dictionaries.
 
@@ -810,7 +808,7 @@ class TestPklAsGraph:
 @pytest.fixture(autouse=True, name="tmp_list_dict_rixs")
 def fixture_tmp_list_dict_rixs(
     tmp_path: Path,
-) -> Tuple[Path, Tuple[str, str, str]]:
+) -> tuple[Path, tuple[str, str, str]]:
     """Fixture for temporary list of dictionaries.
 
     Args:
@@ -845,7 +843,7 @@ class TestRixsConverter:
 
     def test_convertet(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
     ) -> None:
         """Test the converter.
 
@@ -866,7 +864,7 @@ class TestRixsConverter:
     @pytest.mark.parametrize("export_format", ["json", "toml", "lock", "npy", "npz"])
     def test_save(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
         export_format: str,
     ) -> None:
         """Test the save function for various export formats.
@@ -908,7 +906,7 @@ class TestRixsConverter:
 
     def test_raise_error_save(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
     ) -> None:
         """Test the raise error.
 
@@ -927,7 +925,7 @@ class TestRixsConverter:
     @pytest.mark.parametrize("mode", ["sum", "mean"])
     def test_create_rixs(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
         mode: str,
     ) -> None:
         """Test the create rixs.
@@ -951,7 +949,7 @@ class TestRixsConverter:
 
     def test_create_rixs_fail_1(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
     ) -> None:
         """Test the create rixs fail.
 
@@ -978,8 +976,8 @@ class TestRixsConverter:
     )
     def test_create_rixs_fail_2(
         self,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
-        keys: Tuple[str, str, str],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
+        keys: tuple[str, str, str],
     ) -> None:
         """Test the create rixs fail.
 
@@ -1005,7 +1003,7 @@ class TestRixsConverter:
     def test_cmd_pkl_converter(
         self,
         script_runner: Any,
-        tmp_list_dict_rixs: Tuple[Path, Tuple[str, str, str]],
+        tmp_list_dict_rixs: tuple[Path, tuple[str, str, str]],
         export_format: str,
     ) -> None:
         """Test the data converter plugin.

--- a/spectrafit/plugins/test/test_notebook.py
+++ b/spectrafit/plugins/test/test_notebook.py
@@ -6,9 +6,6 @@ import sys
 
 from pathlib import Path
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
 from unittest import mock
 
 import pandas as pd
@@ -71,13 +68,13 @@ def y_column_fixture(dataframe: pd.DataFrame) -> str:
 
 
 @pytest.fixture(name="y_columns")
-def y_columns_fixture(dataframe: pd.DataFrame) -> List[str]:
+def y_columns_fixture(dataframe: pd.DataFrame) -> list[str]:
     """Create a y_column object."""
     return [str(dataframe.columns[2]), str(dataframe.columns[3])]
 
 
 @pytest.fixture(name="initial_model")
-def initial_model_fixture() -> List[Dict[str, Dict[str, Dict[str, Any]]]]:
+def initial_model_fixture() -> list[dict[str, dict[str, dict[str, Any]]]]:
     """Create a DataFrameDisplay object."""
     return [
         {
@@ -99,7 +96,7 @@ def initial_model_fixture() -> List[Dict[str, Dict[str, Dict[str, Any]]]]:
 
 
 @pytest.fixture(name="args_out")
-def args_out_fixture() -> Dict[str, Any]:
+def args_out_fixture() -> dict[str, Any]:
     """Create a DataFrameDisplay object."""
     return {
         "global_": False,
@@ -129,11 +126,11 @@ def args_out_fixture() -> Dict[str, Any]:
 
 @pytest.fixture(name="export_report")
 def export_report_fixture(
-    initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
-    args_out: Dict[str, Any],
+    initial_model: list[dict[str, dict[str, dict[str, Any]]]],
+    args_out: dict[str, Any],
     dataframe: pd.DataFrame,
     dataframe_2: pd.DataFrame,
-) -> Dict[Any, Any]:
+) -> dict[Any, Any]:
     """Create a ExportReport object."""
     return {
         "description": DescriptionAPI(),
@@ -151,9 +148,9 @@ def export_report_fixture(
 @pytest.fixture(name="class_spectrafit")
 def class_spectrafit_fixture(
     dataframe_2: pd.DataFrame,
-    initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+    initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     tmp_path: Path,
-) -> Dict[str, Union[SpectraFitNotebook, Path]]:
+) -> dict[str, SpectraFitNotebook | Path]:
     """Create a SpectraFitNotebook object."""
     _df = pd.DataFrame(data={"x": [1, 2, 3], "y": [1, 2, 3]})
     sp = SpectraFitNotebook(
@@ -191,9 +188,9 @@ def class_spectrafit_fixture(
 @pytest.fixture(name="class_spectrafit_fit_global")
 def class_spectrafit_fixture_fit_global(
     dataframe_global: pd.DataFrame,
-    initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+    initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     tmp_path: Path,
-) -> Dict[str, Union[SpectraFitNotebook, Path]]:
+) -> dict[str, SpectraFitNotebook | Path]:
     """Create a SpectraFitNotebook object."""
     dataframe_init = pd.read_csv(
         "https://github.com/Anselmoo/spectrafit/blob/"
@@ -341,12 +338,15 @@ class TestDataFramePlot:
 
         # Test with combined mocks to avoid long lines
         with mock.patch.object(go.Figure, "update_yaxes") as mock_update_yaxes:
-            with mock.patch(__plotly_io_show__), mock.patch.object(
-                pp, "_create_residual_plot", return_value=go.Figure()
-            ), mock.patch.object(
-                pp, "_create_fit_plot", return_value=go.Figure()
-            ), mock.patch.object(
-                pp, "_plot_single_dataframe", return_value=go.Figure()
+            with (
+                mock.patch(__plotly_io_show__),
+                mock.patch.object(
+                    pp, "_create_residual_plot", return_value=go.Figure()
+                ),
+                mock.patch.object(pp, "_create_fit_plot", return_value=go.Figure()),
+                mock.patch.object(
+                    pp, "_plot_single_dataframe", return_value=go.Figure()
+                ),
             ):
                 # Create a figure with subplots for testing _update_plot_layout
                 fig = make_subplots(rows=2, cols=1)
@@ -424,21 +424,21 @@ class TestExportResults:
 class TestExportReport:
     """Test the ExportReport class."""
 
-    def test_input(self, export_report: Dict[str, Any]) -> None:
+    def test_input(self, export_report: dict[str, Any]) -> None:
         """Test the input function."""
         assert isinstance(
             ExportReport(**export_report).make_input_contribution,
             InputAPI,
         )
 
-    def test_solver(self, export_report: Dict[str, Any]) -> None:
+    def test_solver(self, export_report: dict[str, Any]) -> None:
         """Test the solver function."""
         assert isinstance(
             ExportReport(**export_report).make_solver_contribution,
             SolverAPI,
         )
 
-    def test_output(self, export_report: Dict[str, Any]) -> None:
+    def test_output(self, export_report: dict[str, Any]) -> None:
         """Test the output function."""
         assert isinstance(
             ExportReport(**export_report).make_output_contribution,
@@ -454,7 +454,7 @@ class TestSpectraFitNotebook:
         dataframe: pd.DataFrame,
         x_column: str,
         y_column: str,
-        y_columns: List[str],
+        y_columns: list[str],
     ) -> None:
         """Test the initialization of the class."""
         assert isinstance(
@@ -495,7 +495,7 @@ class TestSpectraFitNotebook:
         assert isinstance(sp.return_df, pd.DataFrame)
         assert isinstance(sp.return_pre_statistic, dict)
 
-    def test_export_df(self, class_spectrafit: Dict[Any, Any]) -> None:
+    def test_export_df(self, class_spectrafit: dict[Any, Any]) -> None:
         """Test the export_df function."""
         class_spectrafit["sp"].export_df_act
         class_spectrafit["sp"].export_df_fit
@@ -545,7 +545,7 @@ class TestSpectraFitNotebook:
     @pytest.mark.webtest
     def test_plot_org(
         self,
-        class_spectrafit: Dict[Any, Any],
+        class_spectrafit: dict[Any, Any],
     ) -> None:
         """Test the plot function."""
         with mock.patch(__plotly_io_show__) as mock_show:
@@ -556,7 +556,7 @@ class TestSpectraFitNotebook:
     @pytest.mark.webtest
     def test_plot_current(
         self,
-        class_spectrafit: Dict[Any, Any],
+        class_spectrafit: dict[Any, Any],
     ) -> None:
         """Test the plot function."""
         with mock.patch(__plotly_io_show__) as mock_show:
@@ -567,7 +567,7 @@ class TestSpectraFitNotebook:
     @pytest.mark.webtest
     def test_plot_preprocess(
         self,
-        class_spectrafit: Dict[Any, Any],
+        class_spectrafit: dict[Any, Any],
     ) -> None:
         """Test the plot function."""
         with mock.patch(__plotly_io_show__) as mock_show:
@@ -578,7 +578,7 @@ class TestSpectraFitNotebook:
     @pytest.mark.webtest
     def test_plot_fit(
         self,
-        class_spectrafit: Dict[Any, Any],
+        class_spectrafit: dict[Any, Any],
     ) -> None:
         """Test the plot function."""
         with mock.patch(__plotly_io_show__) as mock_show:
@@ -589,7 +589,7 @@ class TestSpectraFitNotebook:
     @pytest.mark.webtest
     def test_plot_global(
         self,
-        class_spectrafit_fit_global: Dict[Any, Any],
+        class_spectrafit_fit_global: dict[Any, Any],
     ) -> None:
         """Test the plot function for global fitting routine.
 
@@ -607,7 +607,7 @@ class TestSpectraFitNotebook:
 
     def test_display(
         self,
-        class_spectrafit: Dict[Any, Any],
+        class_spectrafit: dict[Any, Any],
     ) -> None:
         """Test the display function."""
         class_spectrafit["sp"].display_preprocessed_df
@@ -619,8 +619,8 @@ class TestSpectraFitNotebook:
         self,
         class_spectrafit_fit: SpectraFitNotebook,
         dataframe_2: pd.DataFrame,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
-        args_out: Dict[str, Any],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
+        args_out: dict[str, Any],
     ) -> None:
         """Test the generate_report function."""
         sp = class_spectrafit_fit
@@ -638,7 +638,7 @@ class TestSpectraFitNotebook:
     def test_fit(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test the fit function."""
         sp = class_spectrafit_fit
@@ -655,7 +655,7 @@ class TestSpectraFitNotebook:
     def test_fit_new_solver(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test the fit function."""
         sp = class_spectrafit_fit
@@ -673,7 +673,7 @@ class TestSpectraFitNotebook:
     def test_metric(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test the metric plot function."""
         sp = class_spectrafit_fit
@@ -690,7 +690,7 @@ class TestSpectraFitNotebook:
     def test_conv_1(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test conf interval via bool."""
         sp = class_spectrafit_fit
@@ -709,7 +709,7 @@ class TestSpectraFitNotebook:
     def test_conv_2(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test conf interval via bool."""
         sp = class_spectrafit_fit
@@ -729,7 +729,7 @@ class TestSpectraFitNotebook:
     def test_conv_no(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test conf interval via bool for false."""
         sp = class_spectrafit_fit
@@ -762,7 +762,7 @@ class TestSpectraFitNotebook:
     def test_confidence_interval_false_expot(
         self,
         class_spectrafit_fit: SpectraFitNotebook,
-        initial_model: List[Dict[str, Dict[str, Dict[str, Any]]]],
+        initial_model: list[dict[str, dict[str, dict[str, Any]]]],
     ) -> None:
         """Test the confidence interval function."""
         sp = class_spectrafit_fit

--- a/spectrafit/plugins/test/test_rixs_visualizer.py
+++ b/spectrafit/plugins/test/test_rixs_visualizer.py
@@ -6,7 +6,6 @@ import sys
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Tuple
 
 import numpy as np
 import plotly.graph_objects as go
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.skipif(sys.version_info < (3, 9), reason="Requires Python 3.9 or higher")
 @pytest.fixture(scope="module", autouse=True, name="test_data")
-def fixture_test_data() -> Tuple[
+def fixture_test_data() -> tuple[
     NDArray[np.float64],
     NDArray[np.float64],
     NDArray[np.float64],
@@ -92,7 +91,7 @@ class TestRIXSApp:
         self,
         file_format: str,
         tmp_path: Path,
-        test_data: Tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]],
+        test_data: tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.float64]],
     ) -> None:
         """Test the loading of data."""
         data = {

--- a/spectrafit/report.py
+++ b/spectrafit/report.py
@@ -7,12 +7,6 @@ import pprint
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
-from typing import Dict
-from typing import Hashable
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
 from warnings import warn
 
 import numpy as np
@@ -45,6 +39,8 @@ VERBOSE_REGULAR = 1  # Regular output mode
 VERBOSE_DETAILED = 2  # Detailed/verbose output mode
 
 if TYPE_CHECKING:
+    from collections.abc import Hashable
+
     from numpy.typing import NDArray
 
 
@@ -114,7 +110,7 @@ class RegressionMetrics:
         df: pd.DataFrame,
         name_true: str = "intensity",
         name_pred: str = "fit",
-    ) -> Tuple[NDArray[np.float64], NDArray[np.float64]]:
+    ) -> tuple[NDArray[np.float64], NDArray[np.float64]]:
         """Initialize the regression metrics of the Fit(s) for the post analysis.
 
         For this reason, the dataframe is split into two numpy array for true
@@ -153,7 +149,7 @@ class RegressionMetrics:
             (true, pred) if true.shape[1] > 1 else (np.array([true]), np.array([pred]))
         )
 
-    def __call__(self) -> Dict[Hashable, Any]:
+    def __call__(self) -> dict[Hashable, Any]:
         """Calculate the regression metrics of the Fit(s) for the post analysis.
 
         Returns:
@@ -171,7 +167,7 @@ class RegressionMetrics:
             mean_absolute_percentage_error,
             mean_poisson_deviance,
         )
-        metric_dict: Dict[Hashable, Any] = {}
+        metric_dict: dict[Hashable, Any] = {}
         for fnc in metrics_fnc:
             metric_dict[fnc.__name__] = []
             for y_true, y_pred in zip(self.y_true.T, self.y_pred.T):
@@ -192,8 +188,8 @@ class RegressionMetrics:
 def fit_report_as_dict(  # noqa: C901
     inpars: minimize,
     settings: Minimizer,
-    modelpars: Optional[Dict[str, Any]] = None,
-) -> Dict[str, Dict[Any, Any]]:
+    modelpars: dict[str, Any] | None = None,
+) -> dict[str, dict[Any, Any]]:
     """Generate the best fit report as dictionary.
 
     !!! info "About `fit_report_as_dict`"
@@ -226,9 +222,9 @@ def fit_report_as_dict(  # noqa: C901
     result = inpars
     params = inpars.params
 
-    parnames: List[str] = list(params.keys())
+    parnames: list[str] = list(params.keys())
 
-    buffer: Dict[str, Dict[Any, Any]] = {
+    buffer: dict[str, dict[Any, Any]] = {
         "configurations": {},
         "statistics": {},
         "variables": {},
@@ -291,8 +287,8 @@ def fit_report_as_dict(  # noqa: C901
 
 def get_init_value(
     param: Parameter,
-    modelpars: Optional[Parameter] = None,
-) -> Union[float, str]:
+    modelpars: Parameter | None = None,
+) -> float | str:
     """Get the initial value of a parameter.
 
     Args:
@@ -315,8 +311,8 @@ def get_init_value(
 def _extracted_computational_from_results(
     result: minimize,
     settings: Minimizer,
-    buffer: Dict[str, Any],
-) -> Dict[str, Any]:
+    buffer: dict[str, Any],
+) -> dict[str, Any]:
     """Extract the computational from the results.
 
     Args:
@@ -346,9 +342,9 @@ def _extracted_computational_from_results(
 
 def _extracted_gof_from_results(
     result: minimize,
-    buffer: Dict[str, Any],
+    buffer: dict[str, Any],
     params: Parameters,
-) -> Tuple[minimize, Dict[str, Any], Parameters]:
+) -> tuple[minimize, dict[str, Any], Parameters]:
     """Extract the goodness of fit from the results.
 
     Args:
@@ -451,7 +447,7 @@ class CIReport:
 
     def __init__(
         self,
-        ci: Dict[str, List[Tuple[float, float]]],
+        ci: dict[str, list[tuple[float, float]]],
         with_offset: bool = True,
         ndigits: int = 5,
         best_tol: float = 1.0e-2,
@@ -476,7 +472,7 @@ class CIReport:
 
         self.df = pd.DataFrame()
 
-    def convp(self, x: Tuple[float, float], bound_type: str) -> str:
+    def convp(self, x: tuple[float, float], bound_type: str) -> str:
         """Convert the confidence interval to a string.
 
         Args:
@@ -491,7 +487,7 @@ class CIReport:
             "BEST" if abs(x[0]) < self.best_tol else f"{x[0] * 100:.2f}% - {bound_type}"
         )
 
-    def calculate_offset(self, row: List[Tuple[float, float]]) -> float:
+    def calculate_offset(self, row: list[tuple[float, float]]) -> float:
         """Calculate the offset for a row.
 
         Args:
@@ -511,7 +507,7 @@ class CIReport:
     def create_report_row(
         self,
         name: str,
-        row: List[Tuple[float, float]],
+        row: list[tuple[float, float]],
         offset: float,
     ) -> None:
         """Create a row for the report.
@@ -529,7 +525,7 @@ class CIReport:
 
     def __call__(self) -> None:
         """Generate the Confidence report as a table."""
-        self.report: Dict[str, Dict[str, float]] = {}
+        self.report: dict[str, dict[str, float]] = {}
         for name, row in self.ci.items():
             offset = self.calculate_offset(row)
             self.create_report_row(name, row, offset)
@@ -579,11 +575,11 @@ class FitReport:
 
     def __init__(
         self,
-        inpars: Union[Parameters, Callable[..., Any]],
-        sort_pars: Union[bool, Callable[[str], Any]] = True,
+        inpars: Parameters | Callable[..., Any],
+        sort_pars: bool | Callable[[str], Any] = True,
         show_correl: bool = True,
         min_correl: float = 0.0,
-        modelpars: Optional[Callable[..., Any]] = None,
+        modelpars: Callable[..., Any] | None = None,
     ) -> None:
         """Initialize the Report object.
 
@@ -614,7 +610,7 @@ class FitReport:
 
         self.parnames = self._get_parnames()
 
-    def _get_parnames(self) -> List[str]:
+    def _get_parnames(self) -> list[str]:
         """Get parameter names, sorted if required.
 
         Returns:
@@ -626,7 +622,7 @@ class FitReport:
         key = self.sort_pars if callable(self.sort_pars) else alphanumeric_sort
         return sorted(self.params, key=key)
 
-    def generate_fit_statistics(self) -> Optional[pd.DataFrame]:
+    def generate_fit_statistics(self) -> pd.DataFrame | None:
         """Generate fit statistics based on the result of the fitting process.
 
         Returns:
@@ -745,7 +741,7 @@ class FitReport:
                         ]  # mirror the value
         return correl_matrix.fillna(1)  # fill diagonal with 1s
 
-    def generate_report(self) -> Dict[str, pd.DataFrame]:
+    def generate_report(self) -> dict[str, pd.DataFrame]:
         """Generate a report.
 
         !!! info "About the Report"
@@ -790,7 +786,7 @@ class PrintingResults:
 
     def __init__(
         self,
-        args: Dict[str, Any],
+        args: dict[str, Any],
         result: Any,
         minimizer: Minimizer,
     ) -> None:
@@ -817,7 +813,7 @@ class PrintingResults:
             self.printing_verbose_mode()
 
     @staticmethod
-    def print_tabulate(args: Dict[str, Any]) -> None:
+    def print_tabulate(args: dict[str, Any]) -> None:
         """Print the results of the fitting process.
 
         Args:

--- a/spectrafit/spectrafit.py
+++ b/spectrafit/spectrafit.py
@@ -6,10 +6,6 @@ import argparse
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import MutableMapping
-from typing import Optional
-from typing import Tuple
 
 from spectrafit.api.cmd_model import CMDModelAPI
 from spectrafit.models.builtin import SolverModels
@@ -24,13 +20,15 @@ from spectrafit.tools import read_input_file
 
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     import pandas as pd
 
 
 __status__ = PrintingStatus()
 
 
-def get_args() -> Dict[str, Any]:
+def get_args() -> dict[str, Any]:
     """Get the arguments from the command line.
 
     Returns:
@@ -193,7 +191,7 @@ def get_args() -> Dict[str, Any]:
     return vars(parser.parse_args())
 
 
-def command_line_runner(args: Optional[Dict[str, Any]] = None) -> None:
+def command_line_runner(args: dict[str, Any] | None = None) -> None:
     """Run spectrafit from the command line.
 
     Args:
@@ -225,7 +223,7 @@ def command_line_runner(args: Optional[Dict[str, Any]] = None) -> None:
         __status__.yes_no()
 
 
-def extracted_from_command_line_runner() -> Dict[str, Any]:
+def extracted_from_command_line_runner() -> dict[str, Any]:
     """Extract the input commands from the terminal.
 
     Raises:
@@ -237,7 +235,7 @@ def extracted_from_command_line_runner() -> Dict[str, Any]:
              information beyond the command line arguments.
 
     """
-    result: Dict[str, Any] = get_args()
+    result: dict[str, Any] = get_args()
     _args: MutableMapping[str, Any] = read_input_file(result["input"])
 
     if "settings" in _args:
@@ -275,7 +273,7 @@ def extracted_from_command_line_runner() -> Dict[str, Any]:
     return result
 
 
-def fitting_routine(args: Dict[str, Any]) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+def fitting_routine(args: dict[str, Any]) -> tuple[pd.DataFrame, dict[str, Any]]:
     """Run the fitting algorithm.
 
     Args:

--- a/spectrafit/test/test_moessbauer_models_fixed.py
+++ b/spectrafit/test/test_moessbauer_models_fixed.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Union
 
 import numpy as np
 
@@ -26,7 +25,7 @@ from spectrafit.models.moessbauer import moessbauer_singlet
 
 
 def _ensure_float64(
-    arr: Union[NDArray[np.float64], NDArray[np.floating[Any]]],
+    arr: NDArray[np.float64] | NDArray[np.floating[Any]],
 ) -> NDArray[np.float64]:
     """Convert ndarray to float64 to satisfy mypy type checking.
 

--- a/spectrafit/test/test_report.py
+++ b/spectrafit/test/test_report.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 from math import isclose
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -73,7 +70,7 @@ def test_extracted_gof_from_results(mocker: MockerFixture) -> None:
         result.method = "not_a_method"
         with mocker.patch("spectrafit.report._extracted_gof_from_results") as params:
             params = mocker.MagicMock()
-            buffer: Dict[str, Dict[Any, Any]] = {
+            buffer: dict[str, dict[Any, Any]] = {
                 "configurations": {},
                 "statistics": {},
                 "variables": {},
@@ -125,7 +122,7 @@ def par_expr() -> Parameter:
     scope="module",
     name="par_model",
 )
-def par_model() -> Dict[str, Union[Parameter, Parameters]]:
+def par_model() -> dict[str, Parameter | Parameters]:
     """Parameter with expression."""
     modelpars = Parameters()
     modelpars.add("param", value=2.0)
@@ -145,7 +142,7 @@ def par_fixed() -> Parameter:
 def test_get_init_value(
     par_init: Parameter,
     par_expr: Parameter,
-    par_model: Dict[str, Union[Parameter, Parameters]],
+    par_model: dict[str, Parameter | Parameters],
     par_fixed: Parameter,
 ) -> None:
     """Test of the get init value."""
@@ -220,8 +217,8 @@ def test_fit_report_init(
     sort_pars: bool,
     show_correl: bool,
     min_correl: float,
-    modelpars: Union[None, Dict[str, Parameters]],
-    expected_parnames: List[str],
+    modelpars: None | dict[str, Parameters],
+    expected_parnames: list[str],
 ) -> None:
     """Test the initialization of the FitReport class.
 
@@ -256,8 +253,8 @@ def test_fit_report_init(
     ids=["empty-parameters", "incorrect-type"],
 )
 def test_generate_fit_statistics_edge_cases(
-    inpars: Union[Parameters, str],
-    expected_result: Union[None, Exception],
+    inpars: Parameters | str,
+    expected_result: None | Exception,
 ) -> None:
     """Test the edge cases of the  method in the FitReport class.
 
@@ -287,7 +284,7 @@ def test_generate_fit_statistics_edge_cases(
     ],
     ids=["list-instead-parameters"],
 )
-def test_fit_report_init_error_cases(inpars: List[Any], exception: Exception) -> None:
+def test_fit_report_init_error_cases(inpars: list[Any], exception: Exception) -> None:
     """Test the initialization of FitReport with error cases.
 
     Args:
@@ -338,7 +335,7 @@ def test_fit_report_init_error_cases(inpars: List[Any], exception: Exception) ->
     ],
 )
 def test_ci_report(
-    ci: Dict[str, List[Any]],
+    ci: dict[str, list[Any]],
     with_offset: bool,
     ndigits: int,
     expected_output: pd.DataFrame,

--- a/spectrafit/test/test_tools.py
+++ b/spectrafit/test/test_tools.py
@@ -7,7 +7,6 @@ import pickle
 
 from pathlib import Path
 from typing import Any
-from typing import Dict
 
 import numpy as np
 import pandas as pd
@@ -54,7 +53,7 @@ def df_large() -> pd.DataFrame:
 
 
 @pytest.fixture(name="args_0")
-def args_0() -> Dict[str, Any]:
+def args_0() -> dict[str, Any]:
     """Args fixture."""
     return {
         "autopeak": False,
@@ -85,7 +84,7 @@ def args_0() -> Dict[str, Any]:
 
 
 @pytest.fixture(name="args_1")
-def args_1() -> Dict[str, Any]:
+def args_1() -> dict[str, Any]:
     """Args fixture."""
     return {
         "autopeak": False,
@@ -114,7 +113,7 @@ def args_1() -> Dict[str, Any]:
 
 
 @pytest.fixture(name="args_conf_interval_fail")
-def args_2() -> Dict[str, Any]:
+def args_2() -> dict[str, Any]:
     """Args fixture."""
     return {
         "autopeak": False,
@@ -141,7 +140,7 @@ def args_2() -> Dict[str, Any]:
 
 
 @pytest.fixture(name="args__min_rel_change")
-def args_3() -> Dict[str, Any]:
+def args_3() -> dict[str, Any]:
     """Args fixture."""
     return {
         "autopeak": False,
@@ -360,7 +359,7 @@ class TestPostProcessing:
     def test_post_processing_local(
         self,
         random_dataframe_global: pd.DataFrame,
-        args_0: Dict[str, Any],
+        args_0: dict[str, Any],
     ) -> None:
         """Testing post processing for local fitting."""
         minimizer, result = SolverModels(df=random_dataframe_global, args=args_0)()
@@ -377,7 +376,7 @@ class TestPostProcessing:
     def test_post_processing_global(
         self,
         random_dataframe_global: pd.DataFrame,
-        args_1: Dict[str, Any],
+        args_1: dict[str, Any],
     ) -> None:
         """Testing post processing for global fitting."""
         minimizer, result = SolverModels(df=random_dataframe_global, args=args_1)()
@@ -394,7 +393,7 @@ class TestPostProcessing:
     def test_insight_report_empty_conv(
         self,
         random_dataframe: pd.DataFrame,
-        args_conf_interval_fail: Dict[str, Any],
+        args_conf_interval_fail: dict[str, Any],
     ) -> None:
         """Testing insight report for no report of the confidence interval."""
         minimizer, result = SolverModels(
@@ -414,7 +413,7 @@ class TestPostProcessing:
     def test_insight_report_new_min_rel_change(
         self,
         trace_value: bool,
-        args__min_rel_change: Dict[str, Any],
+        args__min_rel_change: dict[str, Any],
     ) -> None:
         """Testing insight report for no report of the confidence interval."""
         x = np.linspace(0, 2, 100, dtype=np.float64)

--- a/spectrafit/tools.py
+++ b/spectrafit/tools.py
@@ -10,11 +10,6 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Dict
-from typing import MutableMapping
-from typing import Optional
-from typing import Tuple
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -31,13 +26,15 @@ from spectrafit.report import fit_report_as_dict
 
 
 if TYPE_CHECKING:
+    from collections.abc import MutableMapping
+
     from lmfit import Minimizer
 
 
 class PreProcessing:
     """Summarized all pre-processing-filters  together."""
 
-    def __init__(self, df: pd.DataFrame, args: Dict[str, Any]) -> None:
+    def __init__(self, df: pd.DataFrame, args: dict[str, Any]) -> None:
         """Initialize PreProcessing class.
 
         Args:
@@ -51,7 +48,7 @@ class PreProcessing:
         self.df = df
         self.args = args
 
-    def __call__(self) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    def __call__(self) -> tuple[pd.DataFrame, dict[str, Any]]:
         """Apply all pre-processing-filters.
 
         Returns:
@@ -86,7 +83,7 @@ class PreProcessing:
         return (df_copy, self.args)
 
     @staticmethod
-    def energy_range(df: pd.DataFrame, args: Dict[str, Any]) -> pd.DataFrame:
+    def energy_range(df: pd.DataFrame, args: dict[str, Any]) -> pd.DataFrame:
         """Select the energy range for fitting.
 
         Args:
@@ -101,8 +98,8 @@ class PreProcessing:
                  (`x` and `data`), which are shrinked according to the energy range.
 
         """
-        energy_start: Union[int, float] = args["energy_start"]
-        energy_stop: Union[int, float] = args["energy_stop"]
+        energy_start: int | float = args["energy_start"]
+        energy_stop: int | float = args["energy_stop"]
 
         df_copy = df.copy()
         if isinstance(energy_start, (int, float)) and isinstance(
@@ -120,7 +117,7 @@ class PreProcessing:
         return None  # pragma: no cover
 
     @staticmethod
-    def energy_shift(df: pd.DataFrame, args: Dict[str, Any]) -> pd.DataFrame:
+    def energy_shift(df: pd.DataFrame, args: dict[str, Any]) -> pd.DataFrame:
         """Shift the energy axis by a given value.
 
         Args:
@@ -142,7 +139,7 @@ class PreProcessing:
         return df_copy
 
     @staticmethod
-    def oversampling(df: pd.DataFrame, args: Dict[str, Any]) -> pd.DataFrame:
+    def oversampling(df: pd.DataFrame, args: dict[str, Any]) -> pd.DataFrame:
         """Oversampling the data to increase the resolution of the data.
 
         !!! note "About Oversampling"
@@ -176,7 +173,7 @@ class PreProcessing:
         return pd.DataFrame({args["column"][0]: x_values, args["column"][1]: y_values})
 
     @staticmethod
-    def smooth_signal(df: pd.DataFrame, args: Dict[str, Any]) -> pd.DataFrame:
+    def smooth_signal(df: pd.DataFrame, args: dict[str, Any]) -> pd.DataFrame:
         """Smooth the intensity values.
 
         Args:
@@ -205,7 +202,7 @@ class PostProcessing:
     def __init__(
         self,
         df: pd.DataFrame,
-        args: Dict[str, Any],
+        args: dict[str, Any],
         minimizer: Minimizer,
         result: Any,
     ) -> None:
@@ -227,7 +224,7 @@ class PostProcessing:
         self.result = result
         self.data_size = self.check_global_fitting()
 
-    def __call__(self) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    def __call__(self) -> tuple[pd.DataFrame, dict[str, Any]]:
         """Call the post-processing."""
         self.make_insight_report()
         self.make_residual_fit()
@@ -238,7 +235,7 @@ class PostProcessing:
         self.export_desprective_statistic2args()
         return (self.df, self.args)
 
-    def check_global_fitting(self) -> Optional[int]:
+    def check_global_fitting(self) -> int | None:
         """Check if the global fitting is performed.
 
         !!! note "About Global Fitting"
@@ -444,7 +441,7 @@ class PostProcessing:
 class SaveResult:
     """Saving the result of the fitting process."""
 
-    def __init__(self, df: pd.DataFrame, args: Dict[str, Any]) -> None:
+    def __init__(self, df: pd.DataFrame, args: dict[str, Any]) -> None:
         """Initialize SaveResult class.
 
         !!! note "About SaveResult"
@@ -588,7 +585,7 @@ def read_input_file(fname: Path) -> MutableMapping[str, Any]:
     return args
 
 
-def load_data(args: Dict[str, str]) -> pd.DataFrame:
+def load_data(args: dict[str, str]) -> pd.DataFrame:
     """Load the data from a txt file.
 
     !!! note "About the data format"
@@ -634,7 +631,7 @@ def load_data(args: Dict[str, str]) -> pd.DataFrame:
 
 def check_keywords_consistency(
     check_args: MutableMapping[str, Any],
-    ref_args: Dict[str, Any],
+    ref_args: dict[str, Any],
 ) -> None:
     """Check if the keywords are consistent.
 
@@ -725,7 +722,7 @@ def pure_fname(fname: Path) -> Path:
     return pure_fname(_fname) if _fname.suffix else _fname
 
 
-def exclude_none_dictionary(value: Dict[str, Any]) -> Dict[str, Any]:
+def exclude_none_dictionary(value: dict[str, Any]) -> dict[str, Any]:
     """Exclude `None` values from the dictionary.
 
     Args:
@@ -745,7 +742,7 @@ def exclude_none_dictionary(value: Dict[str, Any]) -> Dict[str, Any]:
     return value
 
 
-def transform_nested_types(value: Dict[str, Any]) -> Dict[str, Any]:
+def transform_nested_types(value: dict[str, Any]) -> dict[str, Any]:
     """Transform nested types numpy values to python values.
 
     Args:

--- a/spectrafit/utilities/test/test_transformer.py
+++ b/spectrafit/utilities/test/test_transformer.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
-from typing import List
 
 import pytest
 
@@ -13,7 +11,7 @@ from spectrafit.utilities.transformer import remove_none_type
 
 
 @pytest.fixture
-def reference_dict() -> Dict[str, Dict[str, Any]]:
+def reference_dict() -> dict[str, dict[str, Any]]:
     """Check reference dictionary.
 
     Returns:
@@ -43,7 +41,7 @@ def reference_dict() -> Dict[str, Dict[str, Any]]:
 
 
 @pytest.fixture
-def reference_list() -> List[Dict[str, Any]]:
+def reference_list() -> list[dict[str, Any]]:
     """Check reference list dictionary.
 
     Returns:
@@ -71,8 +69,8 @@ def reference_list() -> List[Dict[str, Any]]:
 
 
 def test_converter(
-    reference_list: List[Dict[str, Any]],
-    reference_dict: Dict[str, Dict[str, Any]],
+    reference_list: list[dict[str, Any]],
+    reference_dict: dict[str, dict[str, Any]],
 ) -> None:
     """Test of the converter from list to dict.
 

--- a/spectrafit/utilities/transformer.py
+++ b/spectrafit/utilities/transformer.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 from typing import Any
-from typing import Dict
-from typing import List
-from typing import Union
 
 from spectrafit.api.models_model import DistributionModelAPI
 
 
 def list2dict(
-    peak_list: List[Dict[str, Dict[str, Dict[str, Any]]]],
-) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    peak_list: list[dict[str, dict[str, dict[str, Any]]]],
+) -> dict[str, dict[str, dict[str, Any]]]:
     """Convert the list of peaks to dictionary.
 
     Args:
@@ -24,14 +21,14 @@ def list2dict(
              parameters for the peaks.
 
     """
-    peaks_dict: Dict[str, Dict[str, Dict[str, Any]]] = {"peaks": {}}
+    peaks_dict: dict[str, dict[str, dict[str, Any]]] = {"peaks": {}}
     for i, peak in enumerate(peak_list, start=1):
         if next(iter(peak)) in DistributionModelAPI().__dict__:
             peaks_dict["peaks"][f"{i}"] = peak
     return peaks_dict
 
 
-def remove_none_type(d: Any) -> Union[Dict[str, Any], List[Any]]:
+def remove_none_type(d: Any) -> dict[str, Any] | list[Any]:
     """Remove None type from dictionary in a recursive fashion.
 
     1. Remove None type from each value in the dictionary


### PR DESCRIPTION
- Updated type hints across multiple test files and modules to replace `Dict`, `List`, `Tuple`, and `Union` with their built-in alternatives (`dict`, `list`, `tuple`, and `|` for union types). 
- Improved consistency and readability of type annotations in the codebase. 
- Ensured compatibility with Python 3.9+ features for type hinting.

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?
