### PR TITLE
ci: downgrade devcontainers/ci action version

### DIFF
--- a/.github/workflows/devcontainer-ci.yml
+++ b/.github/workflows/devcontainer-ci.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: 🐳 Build devcontainer
-        uses: devcontainers/ci@v0.4
+        uses: devcontainers/ci@v0.3.1900000417
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BUILD_NUMBER: ${{ github.run_id  }}


### PR DESCRIPTION
Former `v0.4.0` not exits

### All PR-Submissions:

---

- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
      [Pull Requests](https://github.com/Anselmoo/spectrafit/pulls) for the same
      update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New ✨✨ Feature-Submissions:

---

- [ ] Does your submission pass tests?
- [ ] Have you lint your code locally prior to submission? Fixed:
- [ ] This PR is for a new feature, not a bug fix.

### Changes to ⚙️ Core-Features:

---

- [ ] Have you added an explanation of what your changes do and why you'd like
      us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you successfully run tests with your changes locally?

## Summary by Sourcery

CI:
- Downgrade devcontainers/ci action from v0.4 to v0.3.1900000417 in .github/workflows/devcontainer-ci.yml